### PR TITLE
Tidying schemas

### DIFF
--- a/APIs/schemas/v1.0-receiver-active-schema.json
+++ b/APIs/schemas/v1.0-receiver-active-schema.json
@@ -1,12 +1,19 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Describes an active receiver parameter set",
-  "title": "Active Receiver resource",
+  "description": "Describes a receiver",
+  "title": "Receiver resource",
   "additionalProperties": false,
+  "required":[
+      "sender_id",
+      "master_enable",
+      "activation",
+      "transport_file",
+      "transport_params"
+  ],
   "properties": {
     "sender_id": {
-      "description": "ID of the Sender subscribed to by this Receiver",
+      "description": "ID of the Sender subscribed to by this Receiver. This will be null if the receiver has not been configured to receive anything, or if it is receiving from a non-NMOS sender.",
       "type": [
         "string",
         "null"
@@ -23,9 +30,13 @@
       "description": "Parameters concerned with activation of the transport parameters",
       "type": "object",
       "additionalProperties": false,
+            "required":[
+                "mode",
+                "activation_time"
+            ],
       "properties":{
         "mode": {
-          "description": "mode of activation: immediate (on message rx), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message rx + requested_time), null (no activation scheduled)",
+          "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled)",
           "type": [
             "string",
             "null"
@@ -38,7 +49,7 @@
           ]
         },
         "activation_time": {
-          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating absolute time the current pameters were activated. May be null after startup.",
+          "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating absolute time the receiver was activated with the current parameters. This field may be null after startup.",
           "type": [
               "string",
               "null"
@@ -52,6 +63,10 @@
       "type": "object",
       "description": "Transport file parameters",
       "additionalProperties": false,
+      "required":[
+        "data",
+        "type"
+      ],
       "properties":{
         "data":{
           "description": "Content of the transport file",
@@ -62,7 +77,7 @@
           "default": null
         },
         "type":{
-          "description": "Mime type for file (e.g application/sdp)",
+          "description": "IANA assigned media type for file (e.g application/sdp)",
           "type": [
             "string",
             "null"

--- a/APIs/schemas/v1.0-receiver-response-schema.json
+++ b/APIs/schemas/v1.0-receiver-response-schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "type": "object",
-    "description": "Receiver PATCH response",
-    "title": "Receiver PATCH response resource",
+    "description": "Describes a receiver",
+    "title": "Receiver resource",
     "additionalProperties": false,
     "required":[
         "sender_id",
@@ -37,7 +37,7 @@
             ],
             "properties":{
                 "mode": {
-                    "description": "mode of activation: immediate (on message rx), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message rx + requested_time), activate_immediate (immediate activation requested), null (no activation scheduled). This parameter returns to null once an activation is completed. In a immediate activation the response to the PATCH request this field will be set to 'activate_immediate', but will be null in any subsequent GET requests.",
+                    "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled). This parameter returns to null once an activation is completed. For immediate activations, in the response to the PATCH request this field will be set to 'activate_immediate', but will be null in response to any subsequent GET requests.",
                     "type": [
                         "string",
                         "null"
@@ -50,7 +50,7 @@
                     ]
                 },
                 "requested_time": {
-                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation. This field returns to null once the activation is completed. For an immiedate activation this field will always be null, even in the response to the PATCH request.",
+                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation. This field returns to null once the activation is completed. For an immediate activation this field will always be null, even in the response to the PATCH request.",
                     "type": [
                         "string",
                         "null"
@@ -59,7 +59,7 @@
                     "pattern": "^[0-9]+:[0-9]+$"
                 },
                 "scheduled_time": {
-                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating Time (absolute or relative) the sender will actually activate for scheduled activations, or the time acitvation occured for immediate activations. Is set to null once the activation has completed. For immediate activations, this property will be the time the activation acutally occured in the response to the PATCH request, but null in any GET requests thereafter.",
+                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) the receiver will actually activate for scheduled activations, or the time activation occurred for immediate activations. This field returns to null once the activation is completed. For immediate activations, this property will be the time the activation actually occurred in the response to the PATCH request, but null in response to any GET requests thereafter.",
                     "type": [
                         "string",
                         "null"
@@ -73,6 +73,10 @@
             "type": "object",
             "description": "Transport file parameters",
             "additionalProperties": false,
+            "required":[
+                "data",
+                "type"
+            ],
             "properties":{
                 "data":{
                     "description": "Content of the transport file",
@@ -83,7 +87,7 @@
                     "default": null
                 },
                 "type":{
-                    "description": "Mime type for file (e.g application/sdp)",
+                    "description": "IANA assigned media type for file (e.g application/sdp)",
                     "type": [
                         "string",
                         "null"

--- a/APIs/schemas/v1.0-receiver-stage-schema.json
+++ b/APIs/schemas/v1.0-receiver-stage-schema.json
@@ -25,7 +25,7 @@
       "additionalProperties": false,
       "properties":{
         "mode": {
-          "description": "mode of activation: immediate (on message rx), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message rx + requested_time), null (no activation scheduled)",
+          "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled)",
           "type": [
             "string",
             "null"
@@ -62,7 +62,7 @@
           "default": null
         },
         "type":{
-          "description": "Mime type for file (e.g application/sdp)",
+          "description": "IANA assigned media type for file (e.g application/sdp)",
           "type": [
             "string",
             "null"

--- a/APIs/schemas/v1.0-sender-active-schema.json
+++ b/APIs/schemas/v1.0-sender-active-schema.json
@@ -4,9 +4,16 @@
     "description": "Describes a sender",
     "title": "Sender resource",
     "additionalProperties": false,
+    "required":[
+        "receiver_id",
+        "master_enable",
+        "activation",
+        "transport_file",
+        "transport_params"
+    ],
     "properties": {
         "receiver_id": {
-            "description": "ID of the target Receiver of this Sender (relevant for unicast only)",
+            "description": "ID of the target Receiver of this Sender. This will be null if the sender is operating in multicast mode, or has not been assigned a receiver in unicast mode, or is sending to a non-NMOS receiver in unicast mode.",
             "type": [
                 "string",
                 "null"
@@ -23,9 +30,13 @@
             "description": "Parameters concerned with activation of the transport parameters",
             "type": "object",
             "additionalProperties": false,
+            "required":[
+                "mode",
+                "activation_time"
+            ],
             "properties":{
                 "mode": {
-                    "description": "mode of activation: immediate (on message rx), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message rx + requested_time), null (no activation scheduled)",
+                    "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled)",
                     "type": [
                         "string",
                         "null"
@@ -38,7 +49,7 @@
                     ]
                 },
                 "activation_time": {
-                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating absolute time the current pameters were activated. May be null after startup.",
+                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating absolute time the sender was activated with the current parameters. This field may be null after startup.",
                     "type": [
                         "string",
                         "null"
@@ -46,13 +57,16 @@
                     "default": null,
                     "pattern": "^[0-9]+:[0-9]+$"
                 }
-                
             }
         },
         "transport_file":{
             "type": "object",
             "description": "Transport file parameters",
             "additionalProperties": false,
+            "required":[
+                "data",
+                "type"
+            ],
             "properties":{
                 "data":{
                     "description": "Content of the transport file",
@@ -63,7 +77,7 @@
                     "default": null
                 },
                 "type":{
-                    "description": "Mime type for file (e.g application/sdp)",
+                    "description": "IANA assigned media type for file (e.g application/sdp)",
                     "type": [
                         "string",
                         "null"

--- a/APIs/schemas/v1.0-sender-response-schema.json
+++ b/APIs/schemas/v1.0-sender-response-schema.json
@@ -37,7 +37,7 @@
             ],
             "properties":{
                 "mode": {
-                    "description": "mode of activation: immediate (on message rx), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message rx + requested_time), activate_immediate (immediate activation requested), null (no activation scheduled). This parameter returns to null once an activation is completed. In a immediate activation the response to the PATCH request this field will be set to 'activate_immediate', but will be null in any subsequent GET requests.",
+                    "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled). This parameter returns to null once an activation is completed. For immediate activations, in the response to the PATCH request this field will be set to 'activate_immediate', but will be null in response to any subsequent GET requests.",
                     "type": [
                         "string",
                         "null"
@@ -50,7 +50,7 @@
                     ]
                 },
                 "requested_time": {
-                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation. This field returns to null once the activation is completed. For an immiedate activation this field will always be null, even in the response to the PATCH request.",
+                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation. This field returns to null once the activation is completed. For an immediate activation this field will always be null, even in the response to the PATCH request.",
                     "type": [
                         "string",
                         "null"
@@ -59,7 +59,7 @@
                     "pattern": "^[0-9]+:[0-9]+$"
                 },
                 "scheduled_time": {
-                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating Time (absolute or relative) the sender will actually activate for scheduled activations, or the time acitvation occured for immediate activations. Is set to null once the activation has completed. For immediate activations, this property will be the time the activation acutally occured in the response to the PATCH request, but null in any GET requests thereafter.",
+                    "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) the sender will actually activate for scheduled activations, or the time activation occured for immediate activations. This field returns to null once the activation is completed. For immediate activations, this property will be the time the activation actually occurred in the response to the PATCH request, but null in response to any GET requests thereafter.",
                     "type": [
                         "string",
                         "null"
@@ -87,7 +87,7 @@
                     "default": null
                 },
                 "type":{
-                    "description": "Mime type for file (e.g application/sdp)",
+                    "description": "IANA assigned media type for file (e.g application/sdp)",
                     "type": [
                         "string",
                         "null"
@@ -99,8 +99,8 @@
         "transport_params": {
             "description": "Transport-specific parameters",
             "oneOf": [
-                { "$ref": "v1.0_sender_transport_params_rtp" },
-                { "$ref": "v1.0_sender_transport_params_dash" }
+                { "$ref": "v1.0_sender_transport_params_rtp.json" },
+                { "$ref": "v1.0_sender_transport_params_dash.json" }
             ]
         }
     }

--- a/APIs/schemas/v1.0-sender-stage-schema.json
+++ b/APIs/schemas/v1.0-sender-stage-schema.json
@@ -25,7 +25,7 @@
       "additionalProperties": false,
       "properties":{
         "mode": {
-          "description": "mode of activation: immediate (on message rx), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message rx + requested_time), null (no activation scheduled)",
+          "description": "Mode of activation: immediate (on message receipt), scheduled_absolute (when internal clock >= requested_time), scheduled_relative (when internal clock >= time of message receipt + requested_time), or null (no activation scheduled)",
           "type": [
             "string",
             "null"
@@ -62,7 +62,7 @@
           "default": null
         },
         "type":{
-          "description": "Mime type for file (e.g application/sdp)",
+          "description": "IANA assigned media type for file (e.g application/sdp)",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
* Add required properties to 'active' schemas, like 'response' schemas
* Reinstate '.json' suffix in a couple of $ref for consistency with other schemas
* Fix typos and copy&paste mistakes (sender/receiver) in descriptions
* Change "Mime type" to "IANA assigned media type" for consistency