### PR TITLE
Non-normative documentation improvements

### DIFF
--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -182,7 +182,12 @@ documentation:
                array shall be the parameters applied to the primary leg, and element 1 the secondary leg.
                There shall only be one element present in `transport_params` when SMPTE 2022-7 is not in use.
              body:
-               description: PATCH must comply with the constraints served at /constraints but not all fields are mandatory.
+               description: >
+                PATCH must comply with the constraints served at /constraints but not all fields are mandatory.
+                Any fields not included in the reqest JSON remain unchanged, even if they are a child of a property
+                that was included in the request. For example a request containing changes to a single transport parameter
+                will not alter any other transport parameter, even though the `transport_params` propoerty was part
+                of the request.
                type: !include schemas/v1.0-sender-stage-schema.json
                examples:
                  immediate-activation: !include ../examples/v1.0-sender-patch.json
@@ -363,7 +368,11 @@ documentation:
              `rtp_enable` parameter allows for the individual disabling of SMPTE 2022-7 legs.
            body:
              description: >
-               PATCH must comply with the constraints served at /constraints but not all fields are mandatory.
+              PATCH must comply with the constraints served at /constraints but not all fields are mandatory.
+              Any fields not included in the reqest JSON remain unchanged, even if they are a child of a property
+              that was included in the request. For example a request containing changes to a single transport parameter
+              will not alter any other transport parameter, even though the `transport_params` propoerty was part
+              of the request.
              type: !include schemas/v1.0-receiver-stage-schema.json
              examples:
                activate-immediate: !include ../examples/v1.0-receiver-patch.json

--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -186,7 +186,7 @@ documentation:
                 PATCH must comply with the constraints served at /constraints but not all fields are mandatory.
                 Any fields not included in the reqest JSON remain unchanged, even if they are a child of a property
                 that was included in the request. For example a request containing changes to a single transport parameter
-                will not alter any other transport parameter, even though the `transport_params` propoerty was part
+                will not alter any other transport parameter, even though the `transport_params` property was part
                 of the request.
                type: !include schemas/v1.0-sender-stage-schema.json
                examples:
@@ -200,7 +200,7 @@ documentation:
                    an activation has been cancelled, or an immediate activation has been requested.
                    The response will always contain the full set of parameters in the response schema, and all
                    supported transport parameters. For a request with an immediate activation the API should
-                   only return a response once the new transport parameters have been applied to the sender.
+                   only return a response once the new transport parameters have been applied to the underlying sender.
                    Note the presence of the extra `activation_time` parameter in the response. For immediate activation
                    this should be the time the activation actually occurred as an absolute TAI timestamp.
                    If no activation was requested in the PATCH `activation_time` will be set `null`.
@@ -371,7 +371,7 @@ documentation:
               PATCH must comply with the constraints served at /constraints but not all fields are mandatory.
               Any fields not included in the reqest JSON remain unchanged, even if they are a child of a property
               that was included in the request. For example a request containing changes to a single transport parameter
-              will not alter any other transport parameter, even though the `transport_params` propoerty was part
+              will not alter any other transport parameter, even though the `transport_params` property was part
               of the request.
              type: !include schemas/v1.0-receiver-stage-schema.json
              examples:
@@ -386,7 +386,7 @@ documentation:
                  an activation has been cancelled, or an immediate activation has been requested.
                  The response will always contain the full set of parameters in the response schema, and all
                  supported transport parameters. For a request involving an immediate activation the API
-                 should only return once the transport parameters have been applied to the receiver.
+                 should only return once the transport parameters have been applied to the underlying receiver.
                  Note the presence of the extra `activation_time` parameter in the response. For immediate activation
                  this should be the time the activation actually occurred as an absolute TAI timestamp.
                  If no activation was requested in the `activation_time` will be set `null`.

--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -177,7 +177,7 @@ documentation:
              description: >
                Update staged parameters for sender.
                Note that for activations the `mode` parameter will return to null once the activation
-               is completed.
+               transaction with the client is completed (i.e the response to the PATCH has been sent by the server).
                In SMPTE 2022-7 operation element 0 of the `transport_params`
                array shall be the parameters applied to the primary leg, and element 1 the secondary leg.
                There shall only be one element present in `transport_params` when SMPTE 2022-7 is not in use.
@@ -195,7 +195,7 @@ documentation:
                    an activation has been cancelled, or an immediate activation has been requested.
                    The response will always contain the full set of parameters in the response schema, and all
                    supported transport parameters. For a request with an immediate activation the API should
-                   only return a response once the activation has completed.
+                   only return a response once the new transport parameters have been applied to the sender.
                    Note the presence of the extra `activation_time` parameter in the response. For immediate activation
                    this should be the time the activation actually occurred as an absolute TAI timestamp.
                    If no activation was requested in the PATCH `activation_time` will be set `null`.
@@ -340,7 +340,7 @@ documentation:
            description: >
              Update staged parameters for receiver.
              Note that for activations the `mode` parameter will return to null once the activation
-             is completed.
+             transaction with the client is completed (i.e the response to the PATCH has been sent by the server).
              When a transport file is staged the parameters in that transport file should be propagated to
              their corresponding transport parameters and the response should show these updated values.
              On activation the value of the entries in `transport_parameters` must be used to program
@@ -377,7 +377,7 @@ documentation:
                  an activation has been cancelled, or an immediate activation has been requested.
                  The response will always contain the full set of parameters in the response schema, and all
                  supported transport parameters. For a request involving an immediate activation the API
-                 should only return once the activation has completed.
+                 should only return once the transport parameters have been applied to the receiver.
                  Note the presence of the extra `activation_time` parameter in the response. For immediate activation
                  this should be the time the activation actually occurred as an absolute TAI timestamp.
                  If no activation was requested in the `activation_time` will be set `null`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 This document provides an overview of changes between released versions of this specification.
 
 ## Release (unreleased)
-* Under active development
+*   Under active development

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# **[Proposed Specification]** AMWA Device Connection Management Specification
+#**\[Proposed Specification\]** AMWA Device Connection Management Specification
 
 This repository contains details of this AMWA Specification for controlling aspects of NMOS Devices to effect connection management between Senders and Receivers.
 
 ## Getting started
 
 Readers are advised to be familiar with:
-* The JT-NM Reference Architecture (http://jt-nm.org/)
-* The [overview of Networked Media Open Specifications](https://github.com/AMWA-TV/nmos)
-* The [NMOS Discovery and Registration Specification](https://github.com/AMWA-TV/nmos-discovery-registration) (IS-04)
+*   The JT-NM Reference Architecture <http://jt-nm.org/>
+*   The [overview of Networked Media Open Specifications](https://github.com/AMWA-TV/nmos)
+*   The [NMOS Discovery and Registration Specification](https://github.com/AMWA-TV/nmos-discovery-registration) (IS-04)
 
 Readers should then read the [documentation](docs/) in this repository, and the [APIs](APIs/), which are written in RAML -- if a suitable tool is not available for reading this, then [this](APIs/generateHTML) will create HTML versions.
 
 ## Contents
 
-* README.md -- This file
-* [docs/](docs/) -- Documentation targeting those implementing APIs and clients.
-* [APIs/](APIs/) -- Normative specifications of APIs
-* [examples/](examples/) -- Example JSON requests and responses for APIs
-* [LICENSE](LICENSE) -- Licenses for software and text documents
-* [NOTICE](NOTICE) -- Disclaimer
+*   README.md -- This file
+*   [docs/](docs/) -- Documentation targeting those implementing APIs and clients.
+*   [APIs/](APIs/) -- Normative specifications of APIs
+*   [examples/](examples/) -- Example JSON requests and responses for APIs
+*   [LICENSE](LICENSE) -- Licenses for software and text documents
+*   [NOTICE](NOTICE) -- Disclaimer

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -7,8 +7,8 @@ This document covers common aspects of Connection Management API. Many of these 
 ## API Specifications
 
 The Connection Management API is specified using:
-* The following sub-sections describing common API properties.
-* [RAML](http://raml.org/) documents and [JSON schemas](http://tools.ietf.org/html/draft-zyp-json-schema-04) in the [APIs](../APIs/) folder.
+*   The following sub-sections describing common API properties.
+*   [RAML](http://raml.org/) documents and [JSON schemas](http://tools.ietf.org/html/draft-zyp-json-schema-04) in the [APIs](../APIs/) folder.
 
 Examples of JSON format output are provided in the [examples](../examples/) folder.
 
@@ -34,15 +34,15 @@ At each level of the API from the base resource upwards, the response SHOULD inc
 
 All public APIs are versioned as follows:
 
-* Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/connection/) will provide a list containing the versions of the API present on the node.
-* A versioned API response must include only resources which match the schema for that API version.
-* Data which is held for mismatched minor API versions may be returned if it can be conformed to the correct schema (see example below). Data must never be conformed between major API versions.
+*   Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/connection/) will provide a list containing the versions of the API present on the node.
+*   A versioned API response must include only resources which match the schema for that API version.
+*   Data which is held for mismatched minor API versions may be returned if it can be conformed to the correct schema (see example below). Data must never be conformed between major API versions.
 
 **Example**
 
 A v1.1 API response may include:
-* v1.1 data without modification.
-* Data conforming to schemas less than v2.0 but greater than v1.1, with any non-v1.1 keys removed.
+*   v1.1 data without modification.
+*   Data conforming to schemas less than v2.0 but greater than v1.1, with any non-v1.1 keys removed.
 
 ### Common API Base Resource
 
@@ -54,17 +54,17 @@ A v1.1 API response may include:
 ]
 ```
 
-* Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
-* The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
-* MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
-* MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
-* Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
-* Clients are responsible for identifying the correct API version they require.
+*   Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
+*   The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
+*   MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
+*   MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
+*   Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+*   Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes
 
-* If a client performs a GET or HEAD request it SHOULD correctly handle a 301 response (moved permanently).
-* The client MUST follow the 301 redirect in order to retrieve the required resource.
+*   If a client performs a GET or HEAD request it SHOULD correctly handle a 301 response (moved permanently).
+*   The client MUST follow the 301 redirect in order to retrieve the required resource.
 
 ### Error Codes & Responses
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -23,8 +23,8 @@ Where 'href' or 'host' attributes are specified in the APIs, it is strongly reco
 
 When a Sender or Receiver is first started it may not have all the parameters it needs to operate. For example IP addresses and port numbers may not be set. In this instance:
 
-* Senders and Receivers should present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Parameters such as port numbers may have defaults in various RFCs that should be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, should be set to null.
-* Senders that are not configured (for example have a null source IP address value), should return 404 on their active transport file endpoint, until a usable set of parameters has been activated.
+*   Senders and Receivers should present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Parameters such as port numbers may have defaults in various RFCs that should be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, should be set to null.
+*   Senders that are not configured (for example have a null source IP address value), should return 404 on their active transport file endpoint, until a usable set of parameters has been activated.
 
 However Senders and Receivers may start with parameters already configured, for example through use of a configuration file or manual entry of parameters.
 

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -44,8 +44,8 @@ In order to populate the 'subscription' attribute of IS-04 Senders and Receivers
 
 The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice should be followed when both are in use:
 
-* Where a client updates the Node API subscription, the result on the Connection Management API should be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
-* Where a client updates a Connection Management API Receiver the active 'sender_id' parameter should be populated in the Node API subscription parameter with key 'sender_id'.
-* After a Connection Management API activation the corresponding Sender or Receiver's 'version' property should be updated to the instant of the activation.
+*   Where a client updates the Node API subscription, the result on the Connection Management API should be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
+*   Where a client updates a Connection Management API Receiver the active 'sender_id' parameter should be populated in the Node API subscription parameter with key 'sender_id'.
+*   After a Connection Management API activation the corresponding Sender or Receiver's 'version' property should be updated to the instant of the activation.
 
 Should staged modifications be present when a legacy activation is performed, these parameters must be discarded in favour of those provided via the Node API interface.

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -14,52 +14,52 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 ### Receiver Parameter Sets
 
 #### Core Parameters
-* `source_ip`
-* `interface_ip`
-* `destination_port`
-* `rtp_enabled`
+*   `source_ip`
+*   `interface_ip`
+*   `destination_port`
+*   `rtp_enabled`
 
 #### Multicast Parameters
-* `multicast_ip`
+*   `multicast_ip`
 
 #### FEC Parameters
-* `fec_enabled`
-* `fec_destination_ip`
-* `fec_mode`
-* `fec1D_destination_port`
-* `fec2D_destination_port`
+*   `fec_enabled`
+*   `fec_destination_ip`
+*   `fec_mode`
+*   `fec1D_destination_port`
+*   `fec2D_destination_port`
 
 #### RTCP Parameters
-* `rtcp_enabled`
-* `rtcp_destination_ip`
-* `rtcp_destination_port`
+*   `rtcp_enabled`
+*   `rtcp_destination_ip`
+*   `rtcp_destination_port`
 
 ### Sender Parameter Sets
 
 #### Core Parameters
-* `source_ip`
-* `destination_ip`
-* `source_port`
-* `destination_port`
-* `rtp_enabled`
+*   `source_ip`
+*   `destination_ip`
+*   `source_port`
+*   `destination_port`
+*   `rtp_enabled`
 
 #### FEC Parameters
-* `fec_enabled`
-* `fec_destination_ip`
-* `fec_type`
-* `fec_mode`
-* `fec_block_width`
-* `fec_block_height`
-* `fec1D_destination_port`
-* `fec2D_destination_port`
-* `fec1D_source_port`
-* `fec2D_source_port`
+*   `fec_enabled`
+*   `fec_destination_ip`
+*   `fec_type`
+*   `fec_mode`
+*   `fec_block_width`
+*   `fec_block_height`
+*   `fec1D_destination_port`
+*   `fec2D_destination_port`
+*   `fec1D_source_port`
+*   `fec2D_source_port`
 
 #### RTCP Parameters
-* `rtcp_enabled`
-* `rtcp_destination_ip`
-* `rtcp_destination_port`
-* `rtcp_source_port`
+*   `rtcp_enabled`
+*   `rtcp_destination_ip`
+*   `rtcp_destination_port`
+*   `rtcp_source_port`
 
 ## Interpretation of SDP Files
 All Senders and Receivers should comply with RFC 4566 (Session Description Protocol) when creating and parsing SDP files. Multicast Senders and Receivers should additionally comply with RFC 4570 (SDP Source Filters). Two examples are given below, showing an SDP file and the transport parameters that would be presented at the `/staged` endpoint by a Receiver that has parsed the file.

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -18,5 +18,5 @@ Implementers of Connection Management clients are strongly recommended to suppor
 
 The following procedure is suggested for a live system which needs to migrate between API versions.
 
-* Upgrade API clients to their new versions, which must support all Connection Management API versions you are currently using in your deployment.
-* Upgrade Connection Management API implementations to support the new API version.
+*   Upgrade API clients to their new versions, which must support all Connection Management API versions you are currently using in your deployment.
+*   Upgrade Connection Management API implementations to support the new API version.


### PR DESCRIPTION
- Clarify the behaviour of the API when responding to a PATCH to /staged with a request for immediate activation
- Clarify the behaviour or PATCH requests to /staged when a child parameter (e.g a single transport parameter) is updated.
- All markdown passes linting