### PR TITLE
Remove "default" behaviour from spec, and clarify use of auto

### DIFF
--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -262,7 +262,7 @@ documentation:
                value on each subsequent activation. In cases, such as `destination_ip`, where the parameter changing unexpectedly
                at activation through re-resolution may be undesirable, care should be taken in implementation
                to manage this.
-               If there is an error condition that means `auto` cannot be resolved the active transport paraemters
+               If there is an error condition that means `auto` cannot be resolved, the active transport parameters
                must not change, and the underlying sender must continue as before.
              responses:
                200:
@@ -453,7 +453,7 @@ documentation:
              value on each subsequent activation. In cases, such as `interface_ip`, where the parameter changing unexpectedly
              at activation through re-resolution may be undesirable, care should be taken in implementation
              to manage this.
-             If there is an error condition that means `auto` cannot be resolved the active transport paraemters
+             If there is an error condition that means `auto` cannot be resolved, the active transport parameters
              must not change, and the underlying receiver must continue as before.
            responses:
              200:

--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -254,13 +254,16 @@ documentation:
          /active:
            get:
              description: >
-               Get active sender parameters. On activation all instances of "auto" should be resolved
-               into the actual values that will be used by the sender. For example if a sender has the `destination_ip`
+               Get active sender parameters. On activation all instances of "auto" must be resolved
+               into the actual values that will be used by the sender, unless there is an error condition.
+               For example if a sender has the `destination_ip`
                parameter set to `auto` in /staged then `destination_ip` in /active should show the multicast IP
                chosen by the receiver. The parameter will remain set to `auto` in staged, and may be resolved to a different
                value on each subsequent activation. In cases, such as `destination_ip`, where the parameter changing unexpectedly
                at activation through re-resolution may be undesirable, care should be taken in implementation
                to manage this.
+               If there is an error condition that means `auto` cannot be resolved the active transport paraemters
+               must not change, and the underlying sender must continue as before.
              responses:
                200:
                  body:
@@ -442,13 +445,16 @@ documentation:
        /active:
          get:
            description: >
-             Get active receiver parameters. On activation all instances of "auto" should be resolved
-             into the actual values that will be used by the receiver. For example if a receiver has the `interface_ip`
+             Get active receiver parameters. On activation all instances of "auto" must be resolved
+             into the actual values that will be used by the receiver, unless there is an error condition.
+             For example if a receiver has the `interface_ip`
              parameter set to `auto` in /staged then `interface_ip` in /active should show the IP address of the interface
              chosen by the receiver. The parameter will remain set to `auto` in staged, and may be resolved to a different
              value on each subsequent activation. In cases, such as `interface_ip`, where the parameter changing unexpectedly
              at activation through re-resolution may be undesirable, care should be taken in implementation
              to manage this.
+             If there is an error condition that means `auto` cannot be resolved the active transport paraemters
+             must not change, and the underlying receiver must continue as before.
            responses:
              200:
                body:

--- a/APIs/schemas/v1.0-activation-response-schema.json
+++ b/APIs/schemas/v1.0-activation-response-schema.json
@@ -29,8 +29,7 @@
         "pattern": "^[0-9]+:[0-9]+$"
       }, {
         "type": "null"
-      }],
-      "default": null
+      }]
     },
     "activation_time": {
       "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating the absolute time the receiver will or did actually activate for scheduled activations, or the time activation occurred for immediate activations. On the staged endpoint this field returns to null once the activation is completed. For immediate activations on the staged endpoint this property will be the time the activation actually occurred in the response to the PATCH request, but null in response to any GET requests thereafter.",
@@ -39,8 +38,7 @@
         "pattern": "^[0-9]+:[0-9]+$"
       }, {
         "type": "null"
-      }],
-      "default": null
+      }]
     }
   }
 }

--- a/APIs/schemas/v1.0-activation-schema.json
+++ b/APIs/schemas/v1.0-activation-schema.json
@@ -29,8 +29,7 @@
         "pattern": "^[0-9]+:[0-9]+$"
       }, {
         "type": "null"
-      }],
-      "default": null
+      }]
     }
   }
 }

--- a/APIs/schemas/v1.0-receiver-response-schema.json
+++ b/APIs/schemas/v1.0-receiver-response-schema.json
@@ -18,13 +18,11 @@
         "string",
         "null"
       ],
-      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
-      "default": null
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
     },
     "master_enable": {
       "description": "Master on/off control for receiver",
-      "type": "boolean",
-      "default": true
+      "type": "boolean"
     },
     "activation": {
       "$ref": "v1.0-activation-response-schema.json"
@@ -43,16 +41,14 @@
           "type": [
             "string",
             "null"
-          ],
-          "default": null
+          ]
         },
         "type": {
           "description": "IANA assigned media type for file (e.g application/sdp)",
           "type": [
             "string",
             "null"
-          ],
-          "default": null
+          ]
         }
       }
     },

--- a/APIs/schemas/v1.0-receiver-stage-schema.json
+++ b/APIs/schemas/v1.0-receiver-stage-schema.json
@@ -15,8 +15,7 @@
     },
     "master_enable": {
       "description": "Master on/off control for receiver",
-      "type": "boolean",
-      "default": true
+      "type": "boolean"
     },
     "activation": {
       "$ref": "v1.0-activation-schema.json"

--- a/APIs/schemas/v1.0-sender-response-schema.json
+++ b/APIs/schemas/v1.0-sender-response-schema.json
@@ -17,13 +17,11 @@
         "string",
         "null"
       ],
-      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
-      "default": null
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
     },
     "master_enable": {
       "description": "Master on/off control for receiver",
-      "type": "boolean",
-      "default": true
+      "type": "boolean"
     },
     "activation": {
       "$ref": "v1.0-activation-response-schema.json"

--- a/APIs/schemas/v1.0_receiver_transport_params_rtp.json
+++ b/APIs/schemas/v1.0_receiver_transport_params_rtp.json
@@ -53,8 +53,7 @@
           {
             "pattern": "^auto$"
           }
-        ],
-        "default": "auto"
+        ]
       },
       "destination_port": {
         "type": [
@@ -64,13 +63,11 @@
         "description": "destination port for RTP packets (auto = 5004)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "fec_enabled": {
         "type": "boolean",
-        "description": "FEC on/off",
-        "default": false
+        "description": "FEC on/off"
       },
       "fec_destination_ip": {
         "type": "string",
@@ -84,8 +81,7 @@
           {
             "pattern": "^auto$"
           }
-        ],
-        "default": "auto"
+        ]
       },
       "fec_mode": {
         "type": "string",
@@ -94,8 +90,7 @@
           "auto",
           "1D",
           "2D"
-        ],
-        "default": "auto"
+        ]
       },
       "fec1D_destination_port": {
         "type": [
@@ -105,8 +100,7 @@
         "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "fec2D_destination_port": {
         "type": [
@@ -116,8 +110,7 @@
         "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "rtcp_destination_ip": {
         "type": "string",
@@ -131,13 +124,11 @@
           {
             "pattern": "^auto$"
           }
-        ],
-        "default": "auto"
+        ]
       },
       "rtcp_enabled": {
         "type": "boolean",
-        "description": "RTCP on/off",
-        "default": false
+        "description": "RTCP on/off"
       },
       "rtcp_destination_port": {
         "type": [
@@ -147,13 +138,11 @@
         "description": "destination port for RTCP packets (auto = RTP destination_port + 1)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "rtp_enabled": {
         "type": "boolean",
-        "description": "RTP reception active/inactive",
-        "default": true
+        "description": "RTP reception active/inactive"
       }
     }
   }

--- a/APIs/schemas/v1.0_sender_transport_params_rtp.json
+++ b/APIs/schemas/v1.0_sender_transport_params_rtp.json
@@ -67,6 +67,9 @@
           },
           {
             "format": "ipv6"
+          },
+          {
+            "pattern": "^auto$"
           }
         ]
       },

--- a/APIs/schemas/v1.0_sender_transport_params_rtp.json
+++ b/APIs/schemas/v1.0_sender_transport_params_rtp.json
@@ -19,8 +19,7 @@
           {
             "pattern": "^auto$"
           }
-        ],
-        "default": "auto"
+        ]
       },
       "destination_ip": {
         "type": "string",
@@ -44,8 +43,7 @@
         "description": "source port for RTP packets (auto = 5004)",
         "minimum": 0,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "destination_port": {
         "type": [
@@ -55,13 +53,11 @@
         "description": "destination port for RTP packets (auto = 5004)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "fec_enabled": {
         "type": "boolean",
-        "description": "FEC on/off",
-        "default": false
+        "description": "FEC on/off"
       },
       "fec_destination_ip": {
         "type": "string",
@@ -71,12 +67,8 @@
           },
           {
             "format": "ipv6"
-          },
-          {
-            "pattern": "^auto$"
           }
-        ],
-        "default": "auto"
+        ]
       },
       "fec_type": {
         "type": "string",
@@ -84,8 +76,7 @@
         "enum": [
           "XOR",
           "Reed-Solomon"
-        ],
-        "default": "XOR"
+        ]
       },
       "fec_mode": {
         "type": "string",
@@ -93,22 +84,19 @@
         "enum": [
           "1D",
           "2D"
-        ],
-        "default": "1D"
+        ]
       },
       "fec_block_width": {
         "type": "integer",
         "description": "width of block over which FEC is calculated in packets",
         "minimum": 4,
-        "maximum": 200,
-        "default": 4
+        "maximum": 200
       },
       "fec_block_height": {
         "type": "integer",
         "description": "height of block over which FEC is calculated in packets",
         "minimum": 4,
-        "maximum": 200,
-        "default": 4
+        "maximum": 200
       },
       "fec1D_destination_port": {
         "type": [
@@ -118,8 +106,7 @@
         "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "fec2D_destination_port": {
         "type": [
@@ -129,8 +116,7 @@
         "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "fec1D_source_port": {
         "type": [
@@ -140,8 +126,7 @@
         "description": "source port for RTP FEC packets (auto = RTP source_port + 2)",
         "minimum": 0,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "fec2D_source_port": {
         "type": [
@@ -151,13 +136,11 @@
         "description": "source port for RTP FEC packets (auto = RTP source_port + 4)",
         "minimum": 0,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "rtcp_enabled": {
         "type": "boolean",
-        "description": "rtcp on/off",
-        "default": false
+        "description": "rtcp on/off"
       },
       "rtcp_destination_ip": {
         "type": "string",
@@ -171,8 +154,7 @@
           {
             "pattern": "^auto$"
           }
-        ],
-        "default": "auto"
+        ]
       },
       "rtcp_destination_port": {
         "type": [
@@ -182,8 +164,7 @@
         "description": "destination port for RTCP packets (auto = next highest odd port number after RTP destination_port)",
         "minimum": 1,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "rtcp_source_port": {
         "type": [
@@ -193,13 +174,11 @@
         "description": "source port for RTCP packets (destination port for RTCP packets (auto = RTP destination_port + 1))",
         "minimum": 0,
         "maximum": 65535,
-        "pattern": "^auto$",
-        "default": "auto"
+        "pattern": "^auto$"
       },
       "rtp_enabled": {
         "type": "boolean",
-        "description": "RTP transmission active/inactive",
-        "default": true
+        "description": "RTP transmission active/inactive"
       }
     }
   }


### PR DESCRIPTION
Resolves issue #38 by removing the "default" values from the spec, as they never actually had a meaningful use anyway. Also clarified the use of auto, as per #38.