### PR TITLE
Allow a wider range of response codes in bulk response - resolves #31

### DIFF
--- a/APIs/schemas/v1.0-bulk-response-schema.json
+++ b/APIs/schemas/v1.0-bulk-response-schema.json
@@ -18,10 +18,10 @@
       "code": {
         "description": "HTTP status code that would have resulted from an individual activation on this device",
         "type": "integer",
-	"anyOf": [
-	  { "minimum": 200, "maximum": 299 },
-	  { "minimum": 400, "maximum": 599 }
-	]
+        "anyOf": [
+          { "minimum": 200, "maximum": 299 },
+          { "minimum": 400, "maximum": 599 }
+        ]
       },
       "error": {
         "description": "Human readable message which is suitable for user interface display, and helpful to the user. Only included if 'code' indicates an error state",

--- a/APIs/schemas/v1.0-bulk-response-schema.json
+++ b/APIs/schemas/v1.0-bulk-response-schema.json
@@ -18,7 +18,10 @@
       "code": {
         "description": "HTTP status code that would have resulted from an individual activation on this device",
         "type": "integer",
-        "pattern": "^[245][0-9]{2}$"
+	"anyOf": [
+	  { "minimum": 200, "maximum": 299 },
+	  { "minimum": 400, "maximum": 599 }
+	]
       },
       "error": {
         "description": "Human readable message which is suitable for user interface display, and helpful to the user. Only included if 'code' indicates an error state",

--- a/APIs/schemas/v1.0-bulk-response-schema.json
+++ b/APIs/schemas/v1.0-bulk-response-schema.json
@@ -18,13 +18,7 @@
       "code": {
         "description": "HTTP status code that would have resulted from an individual activation on this device",
         "type": "integer",
-        "enum": [
-          200,
-          202,
-          400,
-          404,
-          500
-        ]
+        "pattern": "^[245][0-9]{2}$"
       },
       "error": {
         "description": "Human readable message which is suitable for user interface display, and helpful to the user. Only included if 'code' indicates an error state",


### PR DESCRIPTION
Settled with ^[245][0-9]{2}$ as the regex for allowable response code - do people feel this is general enough?