### PR TITLE
Add proposed additions for IS-07 transport support

### DIFF
--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -308,6 +308,19 @@ documentation:
                  body:
                    description: >
                      Returned if the resource does not exist or if the sender is not currently configured
+         /transporttype:
+           get:
+             description: >
+               Returns the URN for the transport type employed by this sender.
+             responses:
+               200:
+                 body:
+                   type: !include schemas/transporttype-response-schema.json
+                   example: !include ../examples/transporttype-get.json
+               404:
+                body:
+                 description: >
+                   Returned when the resource does not exist
    /receivers:
      displayName: Receivers
      get:
@@ -487,7 +500,18 @@ documentation:
                body:
                  type: !include schemas/receiver-response-schema.json
                  examples:
-                   running-state: !include ../examples/receiver-active-get-200.json
+                   NormalRTP: !include ../examples/receiver-active-get-200.json
+                   NormalMQTT: !include ../examples/receiver-active-get-200-mqtt.json
                    Uninitialised: !include ../examples/receiver-active-get-200-uninit.json
              404:
                description: Returned when the requested resource does not exist
+       /transporttype:
+         get:
+           description: Returns the URN for the transport type employed by this receiver.
+           responses:
+             200:
+               body:
+                 type: !include schemas/transporttype-response-schema.json
+                 example: !include ../examples/transporttype-get.json
+             404:
+               description: Returned when the resource does not exist

--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -165,7 +165,9 @@ documentation:
                    type: !include schemas/constraints-schema.json
                    examples:
                      SMPTE2022-7: !include ../examples/sender-constraints-get-200-2022-7.json
-                     No2022-7: !include ../examples/sender-constraints-get-200.json
+                     RTPNo2022-7: !include ../examples/sender-constraints-get-200.json
+                     MQTT: !include ../examples/sender-constraints-get-200-mqtt.json
+                     WebSocketPlusExt: !include ../examples/sender-constraints-get-200-websocket-ext.json
               404:
                  description: Returned when the requested resource does not exist
          /staged:
@@ -289,7 +291,8 @@ documentation:
                  body:
                    type: !include schemas/sender-response-schema.json
                    examples:
-                     Normal: !include ../examples/sender-active-get.json
+                     NormalRTP: !include ../examples/sender-active-get.json
+                     NormalMQTT: !include ../examples/sender-active-get-mqtt.json
                      Uninitialised: !include ../examples/sender-active-get-uninit.json
                404:
                  description: Returned when the requested resource does not exist
@@ -362,7 +365,9 @@ documentation:
                  type: !include schemas/constraints-schema.json
                  examples:
                    SMPTE2022-7: !include ../examples/receiver-constraints-get-200-2022-7.json
-                   No2022-7: !include ../examples/receiver-constraints-get-200.json
+                   RTPNo2022-7: !include ../examples/receiver-constraints-get-200.json
+                   MQTT: !include ../examples/receiver-constraints-get-200-mqtt.json
+                   WebSocketPlusExt: !include ../examples/receiver-constraints-get-200-websocket-ext.json
              404:
                description: Returned when the requested resource does not exist
        /staged:

--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -174,7 +174,7 @@ documentation:
                Get staged sender transport parameters object. In SMPTE 2022-7 operation element 0
                of the `transport_params` array shall be the parameters applied to the primary leg, and
                element 1 the secondary leg. There shall only be one element present in `transport_params`
-               when SMPTE 2022-7 is not in use. When the `master_enable` parameter is false the RTP
+               when SMPTE 2022-7 is not in use. When the `master_enable` parameter is false the
                sender should stop transmitting media and the `/transportfile` endpoint should return
                an HTTP 404 response.
              responses:
@@ -398,7 +398,7 @@ documentation:
              their corresponding transport parameters and the response should show these updated values.
              On activation the value of the entries in `transport_parameters` must be used to program
              the receiver, not those in the transport file directly. However while the transport file is still present
-             (i.e `data` is not null) media parameters in the transport file should be applied to the RTP
+             (i.e `data` is not null) media parameters in the transport file should be applied to the
              receiver. Setting `data` to null has no impact on the `transport_parameters` array, or
              any other property.
              Where a transport file has been staged the transport

--- a/APIs/schemas/constraint-schema.json
+++ b/APIs/schemas/constraint-schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Definition of a single constraint record",
+    "title": "Constraint",
+    "definitions": {
+        "constraint": {
+            "type": "object",
+            "description": "The constraints for a single transport parameter",
+            "properties": {
+                "maximum": {
+                    "description": "The inclusive maximum value the parameter can be set to",
+                    "type": [
+                        "integer",
+                        "number"
+                    ]
+                },
+                "minimum": {
+                    "description": "The inclusive minimum value the parameter can be set to",
+                    "type": [
+                        "integer",
+                        "number"
+                    ]
+                },
+                "enum": {
+                    "description": "An array of allowed values",
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "anyOf": [
+                            {
+                                "type": "boolean"
+                            },
+                            {
+                                "type": "integer"
+                            },
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "type": "number"
+                            },
+                            {
+                                "type": "string"
+                            }
+                        ]
+                    }
+                },
+                "pattern": {
+                    "description": "A regex pattern that must be satisfied for this parameter",
+                    "type": "string",
+                    "format": "regex"
+                },
+                "description": {
+                    "description": "A human readable string describing the constraint (optional)",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        }
+    }
+}

--- a/APIs/schemas/constraints-schema-mqtt.json
+++ b/APIs/schemas/constraints-schema-mqtt.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Used to express the dynamic constraints on MQTT transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "patternProperties": {
+    "^ext_[a-z A-Z 0-9 _]+$":{
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    }
+  },
+  "properties": {
+    "destination_host": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
+    "source_host": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
+    "broker_topic": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
+    "source_port": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
+    "destination_port": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    }
+  }
+}

--- a/APIs/schemas/constraints-schema-rtp.json
+++ b/APIs/schemas/constraints-schema-rtp.json
@@ -1,0 +1,75 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "description": "Used to express the dynamic constraints on RTP transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+    "patternProperties": {
+      "^ext_[a-z A-Z 0-9 _]+$":{
+        "$ref": "constraint-schema.json#/definitions/constraint"
+      }
+    },
+    "properties": {
+        "multicast_ip": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "destination_ip": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "destination_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "source_ip": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "interface_ip": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "source_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec_enabled": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec_destination_ip": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec_mode": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec_type": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec_block_width": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec_block_height": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec1D_destination_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec2D_destination_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec1D_source_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "fec2D_source_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "rtcp_enabled": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "rtcp_destination_ip": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "rtcp_destination_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "rtcp_source_port": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        },
+        "rtp_enabled": {
+          "$ref": "constraint-schema.json#/definitions/constraint"
+        }
+    }
+}

--- a/APIs/schemas/constraints-schema-websocket.json
+++ b/APIs/schemas/constraints-schema-websocket.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Used to express the dynamic constraints on WebSocket transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "patternProperties": {
+    "^ext_[a-z A-Z 0-9 _]+$":{
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    }
+  },
+  "properties": {
+    "connection_uri": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    }
+  }
+}

--- a/APIs/schemas/constraints-schema.json
+++ b/APIs/schemas/constraints-schema.json
@@ -5,128 +5,16 @@
   "title": "Constraints",
   "maxitems": 2,
   "items": {
-    "type": "object",
-    "description": "Contains the constraints for one transport leg",
-    "properties": {
-      "multicast_ip": {
-        "$ref": "#/definitions/constraint"
+    "anyOf":[
+      {
+        "$ref": "constraints-schema-rtp.json"
       },
-      "destination_ip": {
-        "$ref": "#/definitions/constraint"
+      {
+        "$ref": "constraints-schema-websocket.json"
       },
-      "destination_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "source_ip": {
-        "$ref": "#/definitions/constraint"
-      },
-      "interface_ip": {
-        "$ref": "#/definitions/constraint"
-      },
-      "source_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec_enabled": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec_destination_ip": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec_mode": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec_type": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec_block_width": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec_block_height": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec1D_destination_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec2D_destination_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec1D_source_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "fec2D_source_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "rtcp_enabled": {
-        "$ref": "#/definitions/constraint"
-      },
-      "rtcp_destination_ip": {
-        "$ref": "#/definitions/constraint"
-      },
-      "rtcp_destination_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "rtcp_source_port": {
-        "$ref": "#/definitions/constraint"
-      },
-      "rtp_enabled": {
-        "$ref": "#/definitions/constraint"
+      {
+        "$ref": "constraints-schema-mqtt.json"
       }
-    }
-  },
-  "definitions": {
-    "constraint": {
-      "type": "object",
-      "description": "The constraints for a single transport parameter",
-      "properties": {
-        "maximum": {
-          "description": "The inclusive maximum value the parameter can be set to",
-          "type": [
-            "integer",
-            "number"
-          ]
-        },
-        "minimum": {
-          "description": "The inclusive minimum value the parameter can be set to",
-          "type": [
-            "integer",
-            "number"
-          ]
-        },
-        "enum": {
-          "description": "An array of allowed values",
-          "type": "array",
-          "minItems": 1,
-          "uniqueItems": true,
-          "items": {
-            "anyOf": [{
-                "type": "boolean"
-              },
-              {
-                "type": "integer"
-              },
-              {
-                "type": "null"
-              },
-              {
-                "type": "number"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          }
-        },
-        "pattern": {
-          "description": "A regex pattern that must be satisfied for this parameter",
-          "type": "string",
-          "format": "regex"
-        },
-        "description": {
-          "description": "A human readable string describing the constraint (optional)",
-          "type": "string"
-        }
-      },
-      "additionalProperties": false
-    }
+    ]
   }
 }

--- a/APIs/schemas/receiver-response-schema.json
+++ b/APIs/schemas/receiver-response-schema.json
@@ -54,11 +54,17 @@
     },
     "transport_params": {
       "description": "Transport-specific parameters",
-      "oneOf": [{
+      "anyOf": [{
           "$ref": "receiver_transport_params_rtp.json"
         },
         {
           "$ref": "receiver_transport_params_dash.json"
+        },
+        {
+          "$ref": "receiver_transport_params_websocket.json"
+        },
+        {
+          "$ref": "receiver_transport_params_mqtt.json"
         }
       ]
     }

--- a/APIs/schemas/receiver-stage-schema.json
+++ b/APIs/schemas/receiver-stage-schema.json
@@ -43,11 +43,17 @@
     },
     "transport_params": {
       "description": "Transport-specific parameters",
-      "oneOf": [{
+      "anyOf": [{
           "$ref": "receiver_transport_params_rtp.json"
         },
         {
           "$ref": "receiver_transport_params_dash.json"
+        },
+        {
+          "$ref": "receiver_transport_params_websocket.json"
+        },
+        {
+          "$ref": "receiver_transport_params_mqtt.json"
         }
       ]
     }

--- a/APIs/schemas/receiver_transport_params_ext.json
+++ b/APIs/schemas/receiver_transport_params_ext.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes external Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "title": "External Receiver Transport Parameters",
+  "type": "object",
+  "patternProperties": {
+    "^ext_[a-z A-Z 0-9 _]+$":{
+      "description": "Properties defined in other AMWA IS specifications",
+      "type":[
+        "string",
+        "boolean",
+        "null",
+        "number"
+      ]
+    }
+  }
+}

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes MQTT Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. MQTT receivers must support all parameters in this schema.",
+  "title": "MQTT Receiver Transport Parameters",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "title": "Receiver Input",
+    "allOf": [
+      { "$ref": "receiver_transport_params_ext.json" },
+      {
+        "type": "object",
+        "properties": {
+          "source_host": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Hostname or IP hosting the MQTT broker. The Receiver should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses formatted as connection URIs. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the receiver has not yet been configured.",
+            "anyOf": [{
+                "pattern": "^auto$"
+              },
+              {
+                "format": "hostname"
+              },
+              {
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "source_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "Source port for MQTT traffic. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+            "minimum": 1,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "broker_topic": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic which MQTT messages will be received from via the MQTT broker. A null value indicates that the receiver has not yet been configured."
+          }
+        }
+      }
+    ]
+  }
+}

--- a/APIs/schemas/receiver_transport_params_rtp.json
+++ b/APIs/schemas/receiver_transport_params_rtp.json
@@ -6,144 +6,150 @@
   "items": {
     "type": "object",
     "title": "Receiver Input",
-    "properties": {
-      "source_ip": {
-        "type": [
-          "string",
-          "null"
-        ],
-        "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
-        "anyOf": [{
-            "format": "ipv4"
+    "allOf": [
+      { "$ref": "receiver_transport_params_ext.json" },
+      {
+        "type": "object",
+        "properties": {
+          "source_ip": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
-          {
-            "format": "ipv6"
+          "multicast_ip": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "IP multicast group address used in multicast operation only. Should be set to null during unicast operation. A null value indicates the parameter has not been configured, or the receiver is operating in unicast mode.",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "multicast_ip": {
-        "type": [
-          "string",
-          "null"
-        ],
-        "description": "IP multicast group address used in multicast operation only. Should be set to null during unicast operation. A null value indicates the parameter has not been configured, or the receiver is operating in unicast mode.",
-        "anyOf": [{
-            "format": "ipv4"
+          "interface_ip": {
+            "type": "string",
+            "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
           },
-          {
-            "format": "ipv6"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "interface_ip": {
-        "type": "string",
-        "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
-        "anyOf": [{
-            "format": "ipv4"
-          },
-          {
-            "format": "ipv6"
-          },
-          {
+          "destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTP packets (auto = 5004)",
+            "minimum": 1,
+            "maximum": 65535,
             "pattern": "^auto$"
-          }
-        ]
-      },
-      "destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTP packets (auto = 5004)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "fec_enabled": {
-        "type": "boolean",
-        "description": "FEC on/off"
-      },
-      "fec_destination_ip": {
-        "type": "string",
-        "description": "May be used if NAT is being used at the destination (auto = multicast_ip (multicast mode) or interface_ip (unicast mode))",
-        "anyOf": [{
-            "format": "ipv4"
           },
-          {
-            "format": "ipv6"
+          "fec_enabled": {
+            "type": "boolean",
+            "description": "FEC on/off"
           },
-          {
+          "fec_destination_ip": {
+            "type": "string",
+            "description": "May be used if NAT is being used at the destination (auto = multicast_ip (multicast mode) or interface_ip (unicast mode))",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
+          },
+          "fec_mode": {
+            "type": "string",
+            "description": "forward error correction mode to apply. (auto = highest possible number of dimensions available)",
+            "enum": [
+              "auto",
+              "1D",
+              "2D"
+            ]
+          },
+          "fec1D_destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2)",
+            "minimum": 1,
+            "maximum": 65535,
             "pattern": "^auto$"
-          }
-        ]
-      },
-      "fec_mode": {
-        "type": "string",
-        "description": "forward error correction mode to apply. (auto = highest possible number of dimensions available)",
-        "enum": [
-          "auto",
-          "1D",
-          "2D"
-        ]
-      },
-      "fec1D_destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "fec2D_destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "rtcp_destination_ip": {
-        "type": "string",
-        "description": "Destination IP address of RTCP packets (auto = multicast_ip (multicast mode) or interface_ip (unicast mode))",
-        "anyOf": [{
-            "format": "ipv4"
           },
-          {
-            "format": "ipv6"
-          },
-          {
+          "fec2D_destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4)",
+            "minimum": 1,
+            "maximum": 65535,
             "pattern": "^auto$"
+          },
+          "rtcp_destination_ip": {
+            "type": "string",
+            "description": "Destination IP address of RTCP packets (auto = multicast_ip (multicast mode) or interface_ip (unicast mode))",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
+          },
+          "rtcp_enabled": {
+            "type": "boolean",
+            "description": "RTCP on/off"
+          },
+          "rtcp_destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTCP packets (auto = RTP destination_port + 1)",
+            "minimum": 1,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "rtp_enabled": {
+            "type": "boolean",
+            "description": "RTP reception active/inactive"
           }
-        ]
-      },
-      "rtcp_enabled": {
-        "type": "boolean",
-        "description": "RTCP on/off"
-      },
-      "rtcp_destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTCP packets (auto = RTP destination_port + 1)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "rtp_enabled": {
-        "type": "boolean",
-        "description": "RTP reception active/inactive"
+        }
       }
-    }
+    ]
   }
 }

--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes WebSocket Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. Receivers must support at least the `connection_uri` parameter.",
+  "title": "WebSocket Receiver Transport Parameters",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "title": "Receiver Input",
+    "allOf": [
+      { "$ref": "receiver_transport_params_ext.json" },
+      {
+        "type": "object",
+        "properties": {
+          "connection_uri": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. A null value indicates that the receiver has not yet been configured.",
+            "anyOf": [{
+                "pattern": "^wss?:\/\/.*"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/APIs/schemas/sender-response-schema.json
+++ b/APIs/schemas/sender-response-schema.json
@@ -28,11 +28,17 @@
     },
     "transport_params": {
       "description": "Transport-specific parameters",
-      "oneOf": [{
+      "anyOf": [{
           "$ref": "sender_transport_params_rtp.json"
         },
         {
           "$ref": "sender_transport_params_dash.json"
+        },
+        {
+          "$ref": "sender_transport_params_websocket.json"
+        },
+        {
+          "$ref": "sender_transport_params_mqtt.json"
         }
       ]
     }

--- a/APIs/schemas/sender-stage-schema.json
+++ b/APIs/schemas/sender-stage-schema.json
@@ -22,11 +22,17 @@
     },
     "transport_params": {
       "description": "Transport-specific parameters",
-      "oneOf": [{
+      "anyOf": [{
           "$ref": "sender_transport_params_rtp.json"
         },
         {
           "$ref": "sender_transport_params_dash.json"
+        },
+        {
+          "$ref": "sender_transport_params_websocket.json"
+        },
+        {
+          "$ref": "sender_transport_params_mqtt.json"
         }
       ]
     }

--- a/APIs/schemas/sender_transport_params_ext.json
+++ b/APIs/schemas/sender_transport_params_ext.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes external Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "title": "External Sender Transport Parameters",
+  "type": "object",
+  "patternProperties": {
+    "^ext_[a-z A-Z 0-9 _]+$":{
+      "description": "Properties defined in other AMWA IS specifications",
+      "type":[
+        "string",
+        "boolean",
+        "null",
+        "number"
+      ]
+    }
+  }
+}

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -1,0 +1,58 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes MQTT Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. MQTT Senders must support all properties in this schema.",
+  "title": "MQTT Sender Transport Parameters",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "title": "Sender Output",
+    "allOf": [
+      { "$ref": "sender_transport_params_ext.json" },
+      {
+        "type": "object",
+        "properties": {
+          "destination_host": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Hostname or IP hosting the MQTT broker. The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the sender has not yet been configured.",
+            "anyOf": [{
+                "pattern": "^auto$"
+              },
+              {
+                "format": "hostname"
+              },
+              {
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "Destination port for MQTT traffic.  If the parameter is set to auto the sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+            "minimum": 1,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "broker_topic": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic which MQTT messages will be sent to on the MQTT broker. A null value indicates that the sender has not yet been configured."
+          }
+        }
+      }
+    ]
+  }
+}

--- a/APIs/schemas/sender_transport_params_rtp.json
+++ b/APIs/schemas/sender_transport_params_rtp.json
@@ -6,183 +6,189 @@
   "items": {
     "type": "object",
     "title": "Sender Output",
-    "properties": {
-      "source_ip": {
-        "type": "string",
-        "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
-        "anyOf": [{
-            "format": "ipv4"
+    "allOf": [
+      { "$ref": "sender_transport_params_ext.json" },
+      {
+        "type": "object",
+        "properties": {
+          "source_ip": {
+            "type": "string",
+            "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
           },
-          {
-            "format": "ipv6"
+          "destination_ip": {
+            "type": "string",
+            "description": "IP address to which RTP packets will be sent. If auto is set the sender should select a multicast address to send to itself. For example it may implement MADCAP (RFC 2730), ZMAAP, or be allocated address by some other system responsible for co-ordination multicast address use.",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
           },
-          {
+          "source_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "source port for RTP packets (auto = 5004)",
+            "minimum": 0,
+            "maximum": 65535,
             "pattern": "^auto$"
-          }
-        ]
-      },
-      "destination_ip": {
-        "type": "string",
-        "description": "IP address to which RTP packets will be sent. If auto is set the sender should select a multicast address to send to itself. For example it may implement MADCAP (RFC 2730), ZMAAP, or be allocated address by some other system responsible for co-ordination multicast address use.",
-        "anyOf": [{
-            "format": "ipv4"
           },
-          {
-            "format": "ipv6"
-          },
-          {
+          "destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTP packets (auto = 5004)",
+            "minimum": 1,
+            "maximum": 65535,
             "pattern": "^auto$"
-          }
-        ]
-      },
-      "source_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "source port for RTP packets (auto = 5004)",
-        "minimum": 0,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTP packets (auto = 5004)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "fec_enabled": {
-        "type": "boolean",
-        "description": "FEC on/off"
-      },
-      "fec_destination_ip": {
-        "type": "string",
-        "description": "May be used if NAT is being used at the destination (auto = destination_ip)",
-        "anyOf": [{
-            "format": "ipv4"
           },
-          {
-            "format": "ipv6"
+          "fec_enabled": {
+            "type": "boolean",
+            "description": "FEC on/off"
           },
-          {
+          "fec_destination_ip": {
+            "type": "string",
+            "description": "May be used if NAT is being used at the destination (auto = destination_ip)",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
+          },
+          "fec_type": {
+            "type": "string",
+            "description": "forward error correction mode to apply",
+            "enum": [
+              "XOR",
+              "Reed-Solomon"
+            ]
+          },
+          "fec_mode": {
+            "type": "string",
+            "description": "forward error correction mode to apply",
+            "enum": [
+              "1D",
+              "2D"
+            ]
+          },
+          "fec_block_width": {
+            "type": "integer",
+            "description": "width of block over which FEC is calculated in packets",
+            "minimum": 4,
+            "maximum": 200
+          },
+          "fec_block_height": {
+            "type": "integer",
+            "description": "height of block over which FEC is calculated in packets",
+            "minimum": 4,
+            "maximum": 200
+          },
+          "fec1D_destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2)",
+            "minimum": 1,
+            "maximum": 65535,
             "pattern": "^auto$"
-          }
-        ]
-      },
-      "fec_type": {
-        "type": "string",
-        "description": "forward error correction mode to apply",
-        "enum": [
-          "XOR",
-          "Reed-Solomon"
-        ]
-      },
-      "fec_mode": {
-        "type": "string",
-        "description": "forward error correction mode to apply",
-        "enum": [
-          "1D",
-          "2D"
-        ]
-      },
-      "fec_block_width": {
-        "type": "integer",
-        "description": "width of block over which FEC is calculated in packets",
-        "minimum": 4,
-        "maximum": 200
-      },
-      "fec_block_height": {
-        "type": "integer",
-        "description": "height of block over which FEC is calculated in packets",
-        "minimum": 4,
-        "maximum": 200
-      },
-      "fec1D_destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "fec2D_destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "fec1D_source_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "source port for RTP FEC packets (auto = RTP source_port + 2)",
-        "minimum": 0,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "fec2D_source_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "source port for RTP FEC packets (auto = RTP source_port + 4)",
-        "minimum": 0,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "rtcp_enabled": {
-        "type": "boolean",
-        "description": "rtcp on/off"
-      },
-      "rtcp_destination_ip": {
-        "type": "string",
-        "description": "IP address to which RTCP packets will be sent (auto = same as RTP destination_ip)",
-        "anyOf": [{
-            "format": "ipv4"
           },
-          {
-            "format": "ipv6"
-          },
-          {
+          "fec2D_destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4)",
+            "minimum": 1,
+            "maximum": 65535,
             "pattern": "^auto$"
+          },
+          "fec1D_source_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "source port for RTP FEC packets (auto = RTP source_port + 2)",
+            "minimum": 0,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "fec2D_source_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "source port for RTP FEC packets (auto = RTP source_port + 4)",
+            "minimum": 0,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "rtcp_enabled": {
+            "type": "boolean",
+            "description": "rtcp on/off"
+          },
+          "rtcp_destination_ip": {
+            "type": "string",
+            "description": "IP address to which RTCP packets will be sent (auto = same as RTP destination_ip)",
+            "anyOf": [{
+                "format": "ipv4"
+              },
+              {
+                "format": "ipv6"
+              },
+              {
+                "pattern": "^auto$"
+              }
+            ]
+          },
+          "rtcp_destination_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "destination port for RTCP packets (auto = RTP destination_port + 1)",
+            "minimum": 1,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "rtcp_source_port": {
+            "type": [
+              "integer",
+              "string"
+            ],
+            "description": "source port for RTCP packets (auto = RTP source_port + 1)",
+            "minimum": 0,
+            "maximum": 65535,
+            "pattern": "^auto$"
+          },
+          "rtp_enabled": {
+            "type": "boolean",
+            "description": "RTP transmission active/inactive"
           }
-        ]
-      },
-      "rtcp_destination_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "destination port for RTCP packets (auto = RTP destination_port + 1)",
-        "minimum": 1,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "rtcp_source_port": {
-        "type": [
-          "integer",
-          "string"
-        ],
-        "description": "source port for RTCP packets (auto = RTP source_port + 1)",
-        "minimum": 0,
-        "maximum": 65535,
-        "pattern": "^auto$"
-      },
-      "rtp_enabled": {
-        "type": "boolean",
-        "description": "RTP transmission active/inactive"
+        }
       }
-    }
+    ]
   }
 }

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Describes WebSocket Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. All senders must support `connection_uri`.",
+  "title": "WebSocket Sender Transport Parameters",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "title": "Sender Output",
+    "allOf": [
+      { "$ref": "sender_transport_params_ext.json" },
+      {
+        "type": "object",
+        "properties": {
+          "connection_uri": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
+            "anyOf": [{
+                "pattern": "^auto$"
+              },
+              {
+                "pattern": "^wss?:\/\/.*"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/APIs/schemas/transporttype-response-schema.json
+++ b/APIs/schemas/transporttype-response-schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Transport Type",
+    "description": "Transport type used by the Sender or Receiver in URN format",
+    "type": "string",
+    "oneOf": [
+      {
+        "enum": [
+          "urn:x-nmos:transport:rtp",
+          "urn:x-nmos:transport:dash",
+          "urn:x-nmos:transport:websocket",
+          "urn:x-nmos:transport:mqtt"
+        ]
+      }
+    ],
+    "format": "uri"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,5 +4,7 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 *   Under active development
 
+*   Add a /transporttype resource
+
 ## Release v1.0
 *   Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This document provides an overview of changes between released versions of this 
 ## Release (unreleased)
 *   Under active development
 
+*   Add support for MQTT and WebSocket transports
 *   Add a /transporttype resource
+*   Add support for externally defined transport parameters
 
 ## Release v1.0
 *   Initial release

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -38,6 +38,10 @@ The active endpoint reflects the current running state of the underlying Sender 
 
 Where a transport protocol is accompanied by file format which advertises connection parameters, this may be exposed via the 'transportfile' endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
 
+#### Transport Type
+
+This endpoint identifies the transport type which is used by this Sender or Receiver. It is intended to enable disambiguation between the parameters sets which may be presented under the other resources.
+
 ### Single & Bulk Interfaces
 
 The API provides a mechanism to modify settings for an individual Sender or Receiver. This is referred to as the 'single' interface.

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 ## Conforming to Schemas
 
-When interacting with a Connection Management API, a client may assume the presence of a core set of attributes for each defined transport type. Other parameters may be defined by the specification, but are optional for implementations given that they may or may not implement a particular feature. Presence of these attributes in an implementation cannot be assumed and must be identified via the '/constraints' resource of a running Device. A list of core attributes, and attributes associated with particular features, is given in [4.1 Behaviour - RTP Transport Type](4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md).
+When interacting with a Connection Management API, a client may assume the presence of a core set of attributes for each defined transport type. Other parameters may be defined by the specification, but are optional for implementations given that they may or may not implement a particular feature. Presence of these attributes in an implementation cannot be assumed and must be identified via the '/constraints' resource of a running Device. A list of core attributes, and attributes associated with particular features, is given in [4.1 Behaviour - RTP Transport Type](4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md) and further pages in section 4.
 
 For core attributes, individual APIs may still constrain their permitted values to a particular range or enumeration, so parsing the constraints is still recommended.
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -38,10 +38,10 @@ Many transport parameters in the API may be set to "auto" in the `/staged` endpo
 In some cases the behaviour is more complex, and may be determined by the vendor. The following sub-sections provide guidance on these more complex cases.
 
 ### Sender `source_ip` and Receiver `interface_ip`
-These parameters specify the interface binding to use for sending or receiving RTP traffic. Use of `auto` here implies the Device should determine for itself which of its interfaces is the most appropriate to use. In Devices where only one interface is available for media traffic this is trivial. In Devices with multiple media network interfaces Devices may use mechanisms such as routing tables, out-of-band controls or evaluation of loading on the interfaces.
+These parameters specify the interface binding to use for sending or receiving traffic. Use of `auto` here implies the Device should determine for itself which of its interfaces is the most appropriate to use. In Devices where only one interface is available for media traffic this is trivial. In Devices with multiple media network interfaces Devices may use mechanisms such as routing tables, out-of-band controls or evaluation of loading on the interfaces.
 
 ### Sender `destination_ip`
-If this parameter is set to auto the Sender is expected to automatically select a multicast address to send on. This may be determined by an external network control system, or through technologies such as MADCAP (RFC 2730) or ZMAAP.
+If this parameter is set to auto the Sender is expected to automatically select an address to send on. This may be determined by an external network control system, or through technologies such as MADCAP (RFC 2730) or ZMAAP.
 
 ## Constraints
 
@@ -52,9 +52,6 @@ It is strongly recommended that API implementations validate requests received f
 ### Constraining Interfaces
 
 The constraints are used to advertise the available network interfaces on the Device. This is done through use of an `enum` constraint, which contains an array of the available interface IP addresses, and the "auto" option. For interfaces capable of operating with IPv6 and IPv4 each interface should have two entries containing the interface's IPv4 and IPv6 addresses. Examples are provided in the API raml documentation.
-
-## Behaviour of Media Information
-SDP files contain both connection information and media information. When a parameter set is activated with an SDP file present in `data` the Receiver should use the media information in the SDP file.
 
 ## Staged Requests Precedence
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -27,8 +27,17 @@ Where a server implementation supports concurrent application of settings change
 # Scheduled Activations
 
 IS-05 provides a mechanism whereby the activation of staged transport parameters can be performed at a particular TAI time, or after a given interval.
+
 The primary use case for this behaviour is to allow the synchronisation of large salvo operations, where multiple pieces of equipment should carry out a change in transport parameters simultaneously. A controller may stage parameters with multiple IS-05 APIs with the same activation timestamp, and know that activation will occur at the same time on all devices regardless of the latency between the controller and the device. It is not intended to act as a mechanism for scheduling activations far in the future.
 
 In the event of an error occurring between scheduling an activation and the activation time, the IS-05 transport parameters should reflect the current state of the device. For example, if a sender is no longer sending data at all it should reflect this by setting `master_enable` to false.
 
 API clients should check back with the API after the expected activation time to ensure activations have completed successfully, and that the device is in the expected state. Note that a client may normally expect to see a change in the IS-04 version timestamp upon a successful update of transport parameters, and should monitor for this version timestamp update via the IS-04 web-socket where IS-05 is being used along-side IS-04.
+
+# Externally Defined Parameters
+
+IS-05 aims to provide a defined core set of parameters for each supported transport type. These parameters are based upon the standard(s) which define the transport type.
+
+In some cases it may be necessary to advertise and accept additional parameters in order to make a connection, for example where an external specification extends an existing transport type in order to fulfil its own requirements. Where this is necessary, IS-05 provides the capability to define additional transport paramaters which use the prefix `ext_`. These transport parameters are governed by the same constraints structure as any other parameter, but are intended to make IS-05 more extensible for these use cases.
+
+Where `ext_` parameters are utilised, their naming, usage and versioning is defined external to IS-05. Clients which are unaware of these external definitions should ignore the presence of the parameter(s) if they need to interact with API endpoints which make use of them.

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -61,6 +61,9 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `rtcp_destination_port`
 *   `rtcp_source_port`
 
+## Behaviour of SDP Media Information
+SDP files contain both connection information and media information. When a parameter set is activated with an SDP file present in `data` the Receiver should use the media information in the SDP file.
+
 ## Interpretation of SDP Files
 All Senders and Receivers should comply with RFC 4566 (Session Description Protocol) when creating and parsing SDP files. Multicast Senders and Receivers should additionally comply with RFC 4570 (SDP Source Filters). Two examples are given below, showing an SDP file and the transport parameters that would be presented at the `/staged` endpoint by a Receiver that has parsed the file.
 
@@ -95,7 +98,7 @@ transport_params:[
 ]
 ```
 
-## Source Specific Multicast
+### Source Specific Multicast
 
 ```
     v=0

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -1,0 +1,24 @@
+# Behaviour: MQTT Transport Type
+
+_(c) AMWA 2017, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
+
+## Transport File Resource
+
+The Sender `/transportfile` resource should not be used for this transport type. This resource should return a '404' error code if requested.
+
+## Parameter Sets
+Senders and Receiver Connection Management endpoints must support a core parameter set as follows.
+
+### Receiver Parameter Sets
+
+#### Core Parameters
+*   `source_host`
+*   `source_port`
+*   `broker_topic`
+
+### Sender Parameter Sets
+
+#### Core Parameters
+*   `destination_host`
+*   `destination_port`
+*   `broker_topic`

--- a/docs/4.3. Behaviour - WebSocket Transport Type.md
+++ b/docs/4.3. Behaviour - WebSocket Transport Type.md
@@ -1,0 +1,20 @@
+# Behaviour: WebSocket Transport Type
+
+_(c) AMWA 2017, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
+
+## Transport File Resource
+
+The Sender `/transportfile` resource should not be used for this transport type. This resource should return a '404' error code if requested.
+
+## Parameter Sets
+Senders and Receiver Connection Management endpoints must support a core parameter set as follows.
+
+### Receiver Parameter Sets
+
+#### Core Parameters
+*   `connection_uri`
+
+### Sender Parameter Sets
+
+#### Core Parameters
+*   `connection_uri`

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -10,6 +10,12 @@ API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with pr
 
 Implementers of the Connection Management API must support at least one API version, and may support more than one at a time.
 
+When supporting multiple API versions, Connection Management APIs must provide translations of resources for backwards compatibility. For example, if the implementation supports v1.0 and v1.1 resources, a v1.0 Connection Management API must provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0.
+
+Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs must not list any Senders or Receivers which make use of this new transport type.
+
+Connection Management APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas.
+
 ## Requirements for Connection Management clients
 
 Implementers of Connection Management clients are strongly recommended to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.

--- a/examples/receiver-active-get-200-mqtt.json
+++ b/examples/receiver-active-get-200-mqtt.json
@@ -1,0 +1,18 @@
+{
+  "sender_id": "eae33112-b56c-4a36-8b68-05ab5b6268bc",
+  "master_enable": true,
+  "activation": {
+    "mode": "activate_immediate",
+    "requested_time": "1541508905:0",
+    "activation_time": "1541508905:263900"
+  },
+  "transport_file": {
+    "data": null,
+    "type": null
+  },
+  "transport_params": [{
+    "source_host": "broker.mydomain.com",
+    "source_port": 1883,
+    "broker_topic": "my_topic_name"
+  }]
+}

--- a/examples/receiver-constraints-get-200-mqtt.json
+++ b/examples/receiver-constraints-get-200-mqtt.json
@@ -1,0 +1,10 @@
+[{
+  "source_host": {},
+  "source_port": {
+    "enum": [
+      1833,
+      8883
+    ]
+  },
+  "broker_topic": {}
+}]

--- a/examples/receiver-constraints-get-200-websocket-ext.json
+++ b/examples/receiver-constraints-get-200-websocket-ext.json
@@ -1,0 +1,8 @@
+[{
+  "connection_uri": {},
+  "ext_subscription_data": {},
+  "ext_retry_timeout": {
+    "maximum": 60,
+    "minimum": 5
+  }
+}]

--- a/examples/receiver-resource-get-200.json
+++ b/examples/receiver-resource-get-200.json
@@ -1,5 +1,6 @@
 [
   "constraints/",
   "staged/",
-  "active/"
+  "active/",
+  "transporttype/"
 ]

--- a/examples/sender-active-get-mqtt.json
+++ b/examples/sender-active-get-mqtt.json
@@ -1,0 +1,14 @@
+{
+  "receiver_id": "69744dfb-0557-4202-b1f1-4d1a741ee2bb",
+  "master_enable": true,
+  "activation": {
+    "mode": "activate_immediate",
+    "requested_time": "1541508905:0",
+    "activation_time": "1541508905:0"
+  },
+  "transport_params": [{
+    "destination_host": "broker.mydomain.com",
+    "destination_port": 1883,
+    "broker_topic": "my_topic_name"
+  }]
+}

--- a/examples/sender-constraints-get-200-mqtt.json
+++ b/examples/sender-constraints-get-200-mqtt.json
@@ -1,0 +1,15 @@
+[{
+  "destination_host": {},
+  "destination_port": {
+    "enum": [
+      1833,
+      8883
+    ]
+  },
+  "broker_topic": {
+    "enum": [
+      "fixedTopicName1",
+      "fixedTopicName2"
+    ]
+  }
+}]

--- a/examples/sender-constraints-get-200-websocket-ext.json
+++ b/examples/sender-constraints-get-200-websocket-ext.json
@@ -1,0 +1,12 @@
+[{
+  "connection_uri": {
+    "enum": [
+      "ws://172.29.80.65:5476/websocketServer"
+    ]
+  },
+  "ext_subscription_data": {
+    "enum": [
+      "fixedConnectionParameter"
+    ]
+  }
+}]

--- a/examples/sender-resource-get-200.json
+++ b/examples/sender-resource-get-200.json
@@ -2,5 +2,6 @@
   "constraints/",
   "staged/",
   "active/",
-  "transportfile/"
+  "transportfile/",
+  "transporttype/"
 ]

--- a/examples/sender-stage-relative-success.json
+++ b/examples/sender-stage-relative-success.json
@@ -1,6 +1,6 @@
 {
   "master_enable": true,
-  "receiver_id": "",
+  "receiver_id": null,
   "activation": {
     "mode": "activate_scheduled_relative",
     "requested_time": "2:0",

--- a/examples/transporttype-get.json
+++ b/examples/transporttype-get.json
@@ -1,0 +1,1 @@
+"urn:x-nmos:transport:mqtt"


### PR DESCRIPTION
Adds the following:
* Support for MQTT and WebSocket transport
* Indication of the transport type for each ID via /transporttype (for where IS-04 is unavailable)
* Support for externally defined parameters which are not core to a given transport type

These will require review from the wider community.