### PR TITLE
Tidy up missing schemas

### DIFF
--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -26,7 +26,7 @@ documentation:
       200:
         body:
           example: !include ../examples/base-get-200.json
-          schema: !include schemas/connectionapi-base.json
+          type: !include schemas/connectionapi-base.json
 /bulk:
   displayName: Bulk control interface
   get:
@@ -35,7 +35,7 @@ documentation:
       200:
         body:
           example: !include ../examples/bulk-base-get-200.json
-          schema: !include schemas/connectionapi-bulk.json
+          type: !include schemas/connectionapi-bulk.json
   /senders:
     description: Target for bulk staging of transport parameters.
     get:
@@ -123,7 +123,7 @@ documentation:
        200:
          body:
            example: !include ../examples/single-root.json
-           schema: !include schemas/connectionapi-single.json
+           type: !include schemas/connectionapi-single.json
    /senders:
      get:
        description: Sender root
@@ -132,6 +132,7 @@ documentation:
            description: List Available Senders. All UUIDs are appended with / to indicate the ID forms part of the URL for the next layer down.
            body:
              example: !include ../examples/resourcelist-get-200.json
+             type: !include schemas/sender-receiver-base.json
      /{senderId}:
          get:
            description: List all the API endpoints for a single sender.
@@ -139,7 +140,7 @@ documentation:
              200:
                body:
                  example: !include ../examples/sender-resource-get-200.json
-                 schema: !include schemas/connectionapi-sender.json
+                 type: !include schemas/connectionapi-sender.json
              404:
                description: Returned when the requested Sender ID does not exist.
          /constraints:
@@ -332,6 +333,7 @@ documentation:
          200:
            body:
              example: !include ../examples/resourcelist-get-200.json
+             type: !include schemas/sender-receiver-base.json
      /{receiverId}:
        get:
          description: List API endpoints
@@ -339,7 +341,7 @@ documentation:
            200:
              body:
                example: !include ../examples/receiver-resource-get-200.json
-               schema: !include schemas/connectionapi-receiver.json
+               type: !include schemas/connectionapi-receiver.json
            404:
              description: Returned when the requested resource does not exist
        /constraints:

--- a/APIs/schemas/sender-receiver-base.json
+++ b/APIs/schemas/sender-receiver-base.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "description": "Describes the Connection API sender/receiver base resource",
+    "title": "Connection API sender/receiver base resource",
+    "items": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/$",
+      "uniqueItems": true
+    }
+  }
+  

--- a/APIs/schemas/sender-receiver-base.json
+++ b/APIs/schemas/sender-receiver-base.json
@@ -1,12 +1,11 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "type": "array",
-    "description": "Describes the Connection API sender/receiver base resource",
-    "title": "Connection API sender/receiver base resource",
-    "items": {
-      "type": "string",
-      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/$",
-      "uniqueItems": true
-    }
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "array",
+  "description": "Describes the Connection API sender/receiver base resource",
+  "title": "Connection API sender/receiver base resource",
+  "items": {
+    "type": "string",
+    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/$",
+    "uniqueItems": true
   }
-  
+}


### PR DESCRIPTION
- Fix bug where RAML 0.8 syntax was used for new resource root schemas
- Add missing schemas for the enumerations of senders and receivers