### PR TITLE
docs: remove note on reverse translations

### DIFF
--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -10,8 +10,6 @@ API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with pr
 
 Implementers of the Connection Management API must support at least one API version, and may support more than one at a time.
 
-When supporting multiple API versions, Connection Management APIs must provide translations of resources for backwards compatibility. For example, if the implementation supports v1.0 and v1.1 resources, a v1.0 Connection Management API must provide a response containing all of these resources by removing keys from v1.1 resources which are not present in v1.0.
-
 Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs must not list any Senders or Receivers which make use of this new transport type.
 
 Connection Management APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas.


### PR DESCRIPTION
This can cause schema violations in earlier versions. If a new parameter or value is added to a given transport type in a later version a decision on its handling may be taken at that point, but it is suggested at present that any implementations which absolutely require a parameter or value which is only exposed in a later version do not translate these to earlier versions as it may be impossible.