### PR TITLE
mqtt: add topic for mqtt WILL messages and other status info

### DIFF
--- a/APIs/schemas/constraints-schema-mqtt.json
+++ b/APIs/schemas/constraints-schema-mqtt.json
@@ -17,6 +17,9 @@
     "broker_topic": {
       "$ref": "constraint-schema.json#/definitions/constraint"
     },
+    "connection_status_broker_topic": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
     "source_port": {
       "$ref": "constraint-schema.json#/definitions/constraint"
     },

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -50,6 +50,13 @@
               "null"
             ],
             "description": "The topic which MQTT messages will be received from via the MQTT broker. A null value indicates that the receiver has not yet been configured."
+          },
+          "connection_status_broker_topic": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic used for MQTT status messages such as MQTT Last Will which are received via the MQTT broker. A null value indicates that the receiver has not yet been configured, or is not using a connection status topic."
           }
         }
       }

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -50,6 +50,13 @@
               "null"
             ],
             "description": "The topic which MQTT messages will be sent to on the MQTT broker. A null value indicates that the sender has not yet been configured."
+          },
+          "connection_status_broker_topic": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The topic which MQTT status messages such as MQTT Last Will are sent to on the MQTT broker. A null value indicates that the sender has not yet been configured, or is not using a connection status topic."
           }
         }
       }

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -15,6 +15,7 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `source_host`
 *   `source_port`
 *   `broker_topic`
+*   `connection_status_broker_topic`
 
 ### Sender Parameter Sets
 
@@ -22,3 +23,4 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `destination_host`
 *   `destination_port`
 *   `broker_topic`
+*   `connection_status_broker_topic`

--- a/examples/receiver-active-get-200-mqtt.json
+++ b/examples/receiver-active-get-200-mqtt.json
@@ -13,6 +13,7 @@
   "transport_params": [{
     "source_host": "broker.mydomain.com",
     "source_port": 1883,
-    "broker_topic": "my_topic_name"
+    "broker_topic": "my_topic_name",
+    "connection_status_broker_topic": "my_status_topic_name"
   }]
 }

--- a/examples/receiver-constraints-get-200-mqtt.json
+++ b/examples/receiver-constraints-get-200-mqtt.json
@@ -6,5 +6,6 @@
       8883
     ]
   },
-  "broker_topic": {}
+  "broker_topic": {},
+  "connection_status_broker_topic": {}
 }]

--- a/examples/sender-active-get-mqtt.json
+++ b/examples/sender-active-get-mqtt.json
@@ -9,6 +9,7 @@
   "transport_params": [{
     "destination_host": "broker.mydomain.com",
     "destination_port": 1883,
-    "broker_topic": "my_topic_name"
+    "broker_topic": "my_topic_name",
+    "connection_status_broker_topic": "my_status_topic_name"
   }]
 }

--- a/examples/sender-constraints-get-200-mqtt.json
+++ b/examples/sender-constraints-get-200-mqtt.json
@@ -11,5 +11,10 @@
       "fixedTopicName1",
       "fixedTopicName2"
     ]
+  },
+  "connection_status_broker_topic": {
+    "enum": [
+      "connStatusTopic"
+    ]
   }
 }]


### PR DESCRIPTION
This adds an extra topic for MQTT Senders/Receivers to use for connection status data, primarily used by the MQTT WILL (lastWillTopic). See https://www.hivemq.com/blog/mqtt-essentials-part-9-last-will-and-testament/. Whilst the main topic could be used for this purpose, it's common practice to use a separate topic (linked to the connection, which may bridge multiple Senders).

NB: It might be nice to shorten this name a little (e.g. status_broker_topic), but at present I've used the suggestion from the IS-07 group.