### PR TITLE
constraints: fix bugs in specification of constraints enums

### DIFF
--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -16,7 +16,7 @@
               "string",
               "null"
             ],
-            "description": "Hostname or IP hosting the MQTT broker. The Receiver should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses formatted as connection URIs. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the receiver has not yet been configured.",
+            "description": "Hostname or IP hosting the MQTT broker. The Receiver should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the receiver has not yet been configured.",
             "anyOf": [{
                 "pattern": "^auto$"
               },

--- a/APIs/schemas/receiver_transport_params_rtp.json
+++ b/APIs/schemas/receiver_transport_params_rtp.json
@@ -47,7 +47,7 @@
           },
           "interface_ip": {
             "type": "string",
-            "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
+            "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
             "anyOf": [{
                 "format": "ipv4"
               },

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -16,7 +16,7 @@
               "string",
               "null"
             ],
-            "description": "Hostname or IP hosting the MQTT broker. The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the sender has not yet been configured.",
+            "description": "Hostname or IP hosting the MQTT broker. The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the sender has not yet been configured.",
             "anyOf": [{
                 "pattern": "^auto$"
               },

--- a/APIs/schemas/sender_transport_params_rtp.json
+++ b/APIs/schemas/sender_transport_params_rtp.json
@@ -13,7 +13,7 @@
         "properties": {
           "source_ip": {
             "type": "string",
-            "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
+            "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
             "anyOf": [{
                 "format": "ipv4"
               },

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -16,7 +16,7 @@
               "string",
               "null"
             ],
-            "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain 'auto', and the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
+            "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
             "anyOf": [{
                 "pattern": "^auto$"
               },


### PR DESCRIPTION
This PR fixes a couple of bugs around specifying the values of enums in the constraints endpoint. The RTP related one will need backporting to the v1.0.x branch.