### PR TITLE
schemas: ensure 'data' and 'type' are both present when patching tran…

### DIFF
--- a/APIs/schemas/receiver-response-schema.json
+++ b/APIs/schemas/receiver-response-schema.json
@@ -28,29 +28,7 @@
       "$ref": "activation-response-schema.json"
     },
     "transport_file": {
-      "type": "object",
-      "description": "Transport file parameters",
-      "additionalProperties": false,
-      "required": [
-        "data",
-        "type"
-      ],
-      "properties": {
-        "data": {
-          "description": "Content of the transport file",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "type": {
-          "description": "IANA assigned media type for file (e.g application/sdp)",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
+      "$ref": "receiver-transport-file.json"
     },
     "transport_params": {
       "description": "Transport-specific parameters",

--- a/APIs/schemas/receiver-stage-schema.json
+++ b/APIs/schemas/receiver-stage-schema.json
@@ -21,25 +21,7 @@
       "$ref": "activation-schema.json"
     },
     "transport_file": {
-      "type": "object",
-      "description": "Transport file parameters",
-      "additionalProperties": false,
-      "properties": {
-        "data": {
-          "description": "Content of the transport file",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "type": {
-          "description": "IANA assigned media type for file (e.g application/sdp)",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      }
+      "$ref": "receiver-transport-file.json"
     },
     "transport_params": {
       "description": "Transport-specific parameters",

--- a/APIs/schemas/receiver-transport-file.json
+++ b/APIs/schemas/receiver-transport-file.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Transport file parameters",
+  "title": "Transport file",
+  "additionalProperties": false,
+  "required": [
+    "data",
+    "type"
+  ],
+  "properties": {
+    "data": {
+      "description": "Content of the transport file",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "type": {
+      "description": "IANA assigned media type for file (e.g application/sdp)",
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  }
+}

--- a/APIs/schemas/receiver-transport-file.json
+++ b/APIs/schemas/receiver-transport-file.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Transport file parameters",
+  "description": "Transport file parameters. 'data' and 'type' must both be strings or both be null",
   "title": "Transport file",
   "additionalProperties": false,
   "required": [


### PR DESCRIPTION
Resolves #47

I haven't modified the schema to mandate that if 'data' is a string 'type' is a string and vice versa as it makes the schema much harder to understand. If this is deemed necessary I'll go back and add it.