### PR TITLE
docs: additional guidance for ST.2022-7 SDP file parsing

### DIFF
--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -165,9 +165,11 @@ transport_params:[
 ## Operation with SMPTE 2022-7
 SMPTE 2022-7 describes redundant streams for RTP connections, and is supported by the Connection Management Specification. This manifests itself in the fact that the JSON which describes constraints and transport parameters resides within an array. Where SMPTE-2022-7 is not supported this array contains only one object. Where SMPTE-2022-7 is supported the array contains two entries. The first entry contains information pertaining to Path 1, the second information pertaining to Path 2.
 
-Where a Receiver supports SMPTE 2022-7 but is required to Receive a non-SMPTE 2022-7 stream, only the first set of transport parameters should be used. `rtp_enabled` in the second set of parameters must be set to false and transport parameters in the SDP file should be mapped onto that first set of parameters in the array.
+Where a Receiver supports SMPTE 2022-7 but is required to receive a non-SMPTE 2022-7 stream, only the first set of transport parameters should be used. `rtp_enabled` in the second set of parameters must be set to false and transport parameters in the SDP file should be mapped onto that first set of parameters in the array.
 
-Connection Management APIs supporting SMPTE 2022-7 must comply with RFC 7104 when creating and interpreting SDP files. Implementors may also wish to consider the guidance given in VSF TR-04. The stream listed first in the SDP file should be interpreted as being Path 1, and be populated to the first transport parameter object in `/staged`, with the inverse being true for Path 2.
+Where a Receiver does not support SMPTE 2022-7 but receives a SMPTE 2022-7 transport file containing two sets of transport parameters it is recommended that it parses the first set of transport parameters found in the file and joins the stream as if it were a non-SMPTE 2022-7 stream. This ensures compatibility with Senders which do not support operation in a non-SMPTE 2022-7 mode.
+
+Connection Management APIs supporting SMPTE 2022-7 must comply with RFC 7104 when creating and interpreting SDP files. Implementers may also wish to consider the guidance given in VSF TR-04. The stream listed first in the SDP file should be interpreted as being Path 1, and be populated to the first transport parameter object in `/staged`, with the inverse being true for Path 2.
 
 The three examples given in RFC 7104 are shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
 


### PR DESCRIPTION
Resolves #67 

This section intentionally doesn't use normative language so that it can be backported onto v1.0.x. It recommends a default behaviour for non-2022-7 Receivers in handling grouped SDP files to cover some common incompatibilities. Individual implementations or deployments may choose to ignore or modify this recommendation to suit their needs.