### PR TITLE
docs: clarify trailing slashes in Device controls

### DIFF
--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -26,7 +26,9 @@ Note as above that the API version is included in the 'type', and in the 'href'.
 
 More details about multi-version support can be found in [5.0. Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API may offer control of multiple Devices in a Node from a single URI. Alternatively there may be multiple instances of the API on one Node, each corresponding to one Device. A seperate 'control' endpoint for each Device's Connection Management instance must be advertised, even if the URI is the same.
+A given instance of the Connection Management API may offer control of multiple Devices in a Node from a single URI. Alternatively there may be multiple instances of the API on one Node, each corresponding to one Device. A separate 'control' endpoint for each Device's Connection Management instance must be advertised, even if the URI is the same.
+
+API implementations may list an 'href' with or without a trailing slash, provided that the trailing slash policy in [2.0. APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. In order to avoid cases of double slashes or missing slashes, clients are required to exercise caution when appending paths onto this 'href'.
 
 ## Sender & Receiver IDs
 


### PR DESCRIPTION
Resolves #65 

Given the number of implementations which will now exist with a trailing slash present in the 'href' I've stopped short of mandating that the (preferred) non-trailing slash version is listed. Instead this adds recommendations for clients in the consistent handling of 'href' attributes.