### PR TITLE
Add text around in-flight activations and bulk mode de-duplication

### DIFF
--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -20,6 +20,14 @@ This is important to ensure that connection management clients do not cache the 
 
 In environments where multiple clients may be operating against a single Connection Management API, it is possible that staging of parameters may result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients should examine the results of HTTP PATCH operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
 
+## In-Progress Activations
+
+When an implementation is in the process of activating a new set of transport parameters, concurrent requests to the API from other clients may result in unexpected results. In order to minimise these cases, implementations are recommended to adopt the following practice:
+
+While an activation is in progress, concurrent GET requests to the `/active` resource SHOULD reflect the current state of the Sender or Receiver as accurately as possible at the instant of the request.
+
+If an API implementation receives a new PATCH request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any GET requests to `/staged` during this time MAY also be blocked until the activation is complete.
+
 ## 'Salvo' Operation
 
 Where a server implementation supports concurrent application of settings changes to underlying Senders and Receivers, it may choose to perform 'bulk' resource operations in a parallel fashion internally. This is an implementation decision and is not a requirement of this specification.

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -32,6 +32,8 @@ If an API implementation receives a new PATCH request to the `/staged` resource 
 
 Where a server implementation supports concurrent application of settings changes to underlying Senders and Receivers, it may choose to perform 'bulk' resource operations in a parallel fashion internally. This is an implementation decision and is not a requirement of this specification.
 
+If a 'bulk' request includes multiple sets of parameters for the same Sender or Receiver ID the behaviour is defined by the implementation. In order to maximise interoperability clients are encouraged not to include the same Sender or Receiver ID multiple times in the same 'bulk' request.
+
 # Scheduled Activations
 
 IS-05 provides a mechanism whereby the activation of staged transport parameters can be performed at a particular TAI time, or after a given interval.


### PR DESCRIPTION
Resolves #49 

I think the in flight activation text ought to be added to v1.1-dev only, but the notes around bulk mode could be safely backported to v1.0.x. Happy to consider other opinions.