### PR TITLE
docs: add upgrade advice around new transport parameters

### DIFF
--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -12,6 +12,8 @@ Implementers of the Connection Management API must support at least one API vers
 
 Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs must not list any Senders or Receivers which make use of this new transport type.
 
+Where new transport parameters are added to a pre-existing transport type in a new version of the Connection Management API, earlier versioned APIs must not list these parameters. New transport parameters should be defined such that a request which omits them can proceed without error. This ensures that servers implementing multiple versions of the Connection Management API can continue to process earlier versioned requests successfully.
+
 Connection Management APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas.
 
 ## Requirements for Connection Management clients


### PR DESCRIPTION
Re-adds advice around multi-version running, but specifically concerning transport parameters.