### PR TITLE
Add mechanism to signal secure vs. insecure MQTT

### DIFF
--- a/APIs/schemas/constraints-schema-mqtt.json
+++ b/APIs/schemas/constraints-schema-mqtt.json
@@ -20,6 +20,9 @@
     "broker_protocol": {
       "$ref": "constraint-schema.json#/definitions/constraint"
     },
+    "broker_authorization": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
     "connection_status_broker_topic": {
       "$ref": "constraint-schema.json#/definitions/constraint"
     },

--- a/APIs/schemas/constraints-schema-mqtt.json
+++ b/APIs/schemas/constraints-schema-mqtt.json
@@ -17,6 +17,9 @@
     "broker_topic": {
       "$ref": "constraint-schema.json#/definitions/constraint"
     },
+    "broker_protocol": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
+    },
     "connection_status_broker_topic": {
       "$ref": "constraint-schema.json#/definitions/constraint"
     },

--- a/APIs/schemas/constraints-schema-websocket.json
+++ b/APIs/schemas/constraints-schema-websocket.json
@@ -10,6 +10,9 @@
   "properties": {
     "connection_uri": {
       "$ref": "constraint-schema.json#/definitions/constraint"
+    },
+    "connection_authorization": {
+      "$ref": "constraint-schema.json#/definitions/constraint"
     }
   }
 }

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -44,6 +44,14 @@
             "maximum": 65535,
             "pattern": "^auto$"
           },
+          "broker_scheme": {
+            "type": "string",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates plain text operation, and 'secure-mqtt' indicates use of TLS.",
+            "enum": [
+              "mqtt",
+              "secure-mqtt"
+            ]
+          },
           "broker_topic": {
             "type": [
               "string",

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -46,7 +46,7 @@
           },
           "broker_protocol": {
             "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration. ",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
             "enum": [
               "auto",
               "mqtt",

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -53,6 +53,18 @@
               "secure-mqtt"
             ]
           },
+          "broker_authorization": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration. ",
+            "enum": [
+              "auto",
+              true,
+              false,
+            ]
+          },
           "broker_topic": {
             "type": [
               "string",

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -44,7 +44,7 @@
             "maximum": 65535,
             "pattern": "^auto$"
           },
-          "broker_scheme": {
+          "broker_protocol": {
             "type": "string",
             "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates plain text operation, and 'secure-mqtt' indicates use of TLS.",
             "enum": [

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -46,8 +46,9 @@
           },
           "broker_protocol": {
             "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS.",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration. ",
             "enum": [
+              "auto",
               "mqtt",
               "secure-mqtt"
             ]

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -58,7 +58,7 @@
               "string",
               "boolean"
             ],
-            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration. ",
+            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
             "enum": [
               "auto",
               true,

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -46,7 +46,7 @@
           },
           "broker_protocol": {
             "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates plain text operation, and 'secure-mqtt' indicates use of TLS.",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS.",
             "enum": [
               "mqtt",
               "secure-mqtt"

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -62,7 +62,7 @@
             "enum": [
               "auto",
               true,
-              false,
+              false
             ]
           },
           "broker_topic": {

--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -24,6 +24,18 @@
                 "type": "null"
               }
             ]
+          },
+          "connection_authorization": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on its own internal configuration.",
+            "enum": [
+              "auto",
+              true,
+              false,
+            ]
           }
         }
       }

--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -34,7 +34,7 @@
             "enum": [
               "auto",
               true,
-              false,
+              false
             ]
           }
         }

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -46,7 +46,7 @@
           },
           "broker_protocol": {
             "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration. ",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
             "enum": [
               "auto",
               "mqtt",
@@ -58,7 +58,7 @@
               "string",
               "boolean"
             ],
-            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration. ",
+            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
             "enum": [
               "auto",
               true,

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -44,7 +44,7 @@
             "maximum": 65535,
             "pattern": "^auto$"
           },
-          "broker_scheme": {
+          "broker_protocol": {
             "type": "string",
             "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates plain text operation, and 'secure-mqtt' indicates use of TLS.",
             "enum": [

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -46,8 +46,9 @@
           },
           "broker_protocol": {
             "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS.",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration. ",
             "enum": [
+              "auto",
               "mqtt",
               "secure-mqtt"
             ]

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -53,6 +53,18 @@
               "secure-mqtt"
             ]
           },
+          "broker_authorization": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration. ",
+            "enum": [
+              "auto",
+              true,
+              false,
+            ]
+          },
           "broker_topic": {
             "type": [
               "string",

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -46,7 +46,7 @@
           },
           "broker_protocol": {
             "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates plain text operation, and 'secure-mqtt' indicates use of TLS.",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS.",
             "enum": [
               "mqtt",
               "secure-mqtt"

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -39,10 +39,18 @@
               "integer",
               "string"
             ],
-            "description": "Destination port for MQTT traffic.  If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+            "description": "Destination port for MQTT traffic. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
             "minimum": 1,
             "maximum": 65535,
             "pattern": "^auto$"
+          },
+          "broker_scheme": {
+            "type": "string",
+            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates plain text operation, and 'secure-mqtt' indicates use of TLS.",
+            "enum": [
+              "mqtt",
+              "secure-mqtt"
+            ]
           },
           "broker_topic": {
             "type": [

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -62,7 +62,7 @@
             "enum": [
               "auto",
               true,
-              false,
+              false
             ]
           },
           "broker_topic": {

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -37,7 +37,7 @@
             "enum": [
               "auto",
               true,
-              false,
+              false
             ]
           }
         }

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -27,6 +27,18 @@
                 "type": "null"
               }
             ]
+          },
+          "connection_authorization": {
+            "type": [
+              "string",
+              "boolean"
+            ],
+            "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on its own internal configuration.",
+            "enum": [
+              "auto",
+              true,
+              false,
+            ]
           }
         }
       }

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -15,6 +15,7 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `source_host`
 *   `source_port`
 *   `broker_topic`
+*   `broker_scheme`
 *   `connection_status_broker_topic`
 
 ### Sender Parameter Sets
@@ -23,4 +24,5 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `destination_host`
 *   `destination_port`
 *   `broker_topic`
+*   `broker_scheme`
 *   `connection_status_broker_topic`

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -16,6 +16,7 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `source_port`
 *   `broker_topic`
 *   `broker_protocol`
+*   `broker_authorization`
 *   `connection_status_broker_topic`
 
 ### Sender Parameter Sets
@@ -25,4 +26,5 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `destination_port`
 *   `broker_topic`
 *   `broker_protocol`
+*   `broker_authorization`
 *   `connection_status_broker_topic`

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -15,7 +15,7 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `source_host`
 *   `source_port`
 *   `broker_topic`
-*   `broker_scheme`
+*   `broker_protocol`
 *   `connection_status_broker_topic`
 
 ### Sender Parameter Sets
@@ -24,5 +24,5 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 *   `destination_host`
 *   `destination_port`
 *   `broker_topic`
-*   `broker_scheme`
+*   `broker_protocol`
 *   `connection_status_broker_topic`

--- a/docs/4.3. Behaviour - WebSocket Transport Type.md
+++ b/docs/4.3. Behaviour - WebSocket Transport Type.md
@@ -13,8 +13,10 @@ Senders and Receiver Connection Management endpoints must support a core paramet
 
 #### Core Parameters
 *   `connection_uri`
+*   `connection_authorization`
 
 ### Sender Parameter Sets
 
 #### Core Parameters
 *   `connection_uri`
+*   `connection_authorization`

--- a/examples/receiver-active-get-200-mqtt.json
+++ b/examples/receiver-active-get-200-mqtt.json
@@ -14,6 +14,8 @@
     "source_host": "broker.mydomain.com",
     "source_port": 1883,
     "broker_topic": "my_topic_name",
+    "broker_protocol": "mqtt",
+    "broker_authorization": false,
     "connection_status_broker_topic": "my_status_topic_name"
   }]
 }

--- a/examples/receiver-constraints-get-200-mqtt.json
+++ b/examples/receiver-constraints-get-200-mqtt.json
@@ -7,5 +7,6 @@
     ]
   },
   "broker_topic": {},
+  "broker_protocol": {},
   "connection_status_broker_topic": {}
 }]

--- a/examples/receiver-constraints-get-200-mqtt.json
+++ b/examples/receiver-constraints-get-200-mqtt.json
@@ -7,6 +7,15 @@
     ]
   },
   "broker_topic": {},
-  "broker_protocol": {},
+  "broker_protocol": {
+    "enum": [
+      false
+    ]
+  },
+  "broker_authorization": {
+    "enum": [
+      false
+    ]
+  },
   "connection_status_broker_topic": {}
 }]

--- a/examples/receiver-constraints-get-200-mqtt.json
+++ b/examples/receiver-constraints-get-200-mqtt.json
@@ -9,7 +9,7 @@
   "broker_topic": {},
   "broker_protocol": {
     "enum": [
-      false
+      "mqtt"
     ]
   },
   "broker_authorization": {

--- a/examples/receiver-constraints-get-200-websocket-ext.json
+++ b/examples/receiver-constraints-get-200-websocket-ext.json
@@ -1,11 +1,6 @@
 [{
   "connection_uri": {},
-  "connection_authorization": {
-    "enum": [
-      true,
-      false
-    ]
-  },
+  "connection_authorization": {},
   "ext_subscription_data": {},
   "ext_retry_timeout": {
     "maximum": 60,

--- a/examples/receiver-constraints-get-200-websocket-ext.json
+++ b/examples/receiver-constraints-get-200-websocket-ext.json
@@ -1,6 +1,11 @@
 [{
   "connection_uri": {},
-  "connection_authorization": {},
+  "connection_authorization": {
+    "enum": [
+      true,
+      false
+    ]
+  },
   "ext_subscription_data": {},
   "ext_retry_timeout": {
     "maximum": 60,

--- a/examples/receiver-constraints-get-200-websocket-ext.json
+++ b/examples/receiver-constraints-get-200-websocket-ext.json
@@ -1,5 +1,6 @@
 [{
   "connection_uri": {},
+  "connection_authorization": {},
   "ext_subscription_data": {},
   "ext_retry_timeout": {
     "maximum": 60,

--- a/examples/sender-active-get-mqtt.json
+++ b/examples/sender-active-get-mqtt.json
@@ -10,6 +10,8 @@
     "destination_host": "broker.mydomain.com",
     "destination_port": 1883,
     "broker_topic": "my_topic_name",
+    "broker_protocol": "mqtt",
+    "broker_authorization": false,
     "connection_status_broker_topic": "my_status_topic_name"
   }]
 }

--- a/examples/sender-constraints-get-200-mqtt.json
+++ b/examples/sender-constraints-get-200-mqtt.json
@@ -14,8 +14,8 @@
   },
   "broker_protocol": {
     "enum": [
-      true,
-      false
+      "mqtt",
+      "secure-mqtt"
     ]
   },
   "broker_authorization": {

--- a/examples/sender-constraints-get-200-mqtt.json
+++ b/examples/sender-constraints-get-200-mqtt.json
@@ -12,18 +12,8 @@
       "fixedTopicName2"
     ]
   },
-  "broker_protocol": {
-    "enum": [
-      "mqtt",
-      "secure-mqtt"
-    ]
-  },
-  "broker_authorization": {
-    "enum": [
-      true,
-      false
-    ]
-  },
+  "broker_protocol": {},
+  "broker_authorization": {},
   "connection_status_broker_topic": {
     "enum": [
       "connStatusTopic"

--- a/examples/sender-constraints-get-200-mqtt.json
+++ b/examples/sender-constraints-get-200-mqtt.json
@@ -12,6 +12,7 @@
       "fixedTopicName2"
     ]
   },
+  "broker_protocol": {},
   "connection_status_broker_topic": {
     "enum": [
       "connStatusTopic"

--- a/examples/sender-constraints-get-200-mqtt.json
+++ b/examples/sender-constraints-get-200-mqtt.json
@@ -12,7 +12,18 @@
       "fixedTopicName2"
     ]
   },
-  "broker_protocol": {},
+  "broker_protocol": {
+    "enum": [
+      true,
+      false
+    ]
+  },
+  "broker_authorization": {
+    "enum": [
+      true,
+      false
+    ]
+  },
   "connection_status_broker_topic": {
     "enum": [
       "connStatusTopic"

--- a/examples/sender-constraints-get-200-websocket-ext.json
+++ b/examples/sender-constraints-get-200-websocket-ext.json
@@ -6,7 +6,6 @@
   },
   "connection_authorization": {
     "enum": [
-      true,
       false
     ]
   },

--- a/examples/sender-constraints-get-200-websocket-ext.json
+++ b/examples/sender-constraints-get-200-websocket-ext.json
@@ -4,6 +4,7 @@
       "ws://172.29.80.65:5476/websocketServer"
     ]
   },
+  "connection_authorization": {},
   "ext_subscription_data": {
     "enum": [
       "fixedConnectionParameter"

--- a/examples/sender-constraints-get-200-websocket-ext.json
+++ b/examples/sender-constraints-get-200-websocket-ext.json
@@ -4,7 +4,12 @@
       "ws://172.29.80.65:5476/websocketServer"
     ]
   },
-  "connection_authorization": {},
+  "connection_authorization": {
+    "enum": [
+      true,
+      false
+    ]
+  },
   "ext_subscription_data": {
     "enum": [
       "fixedConnectionParameter"


### PR DESCRIPTION
This is one option to resolve #80 if we choose to.

I haven't included authorization as yet, but this brings MQTT into line with what is visible for WebSockets.

I've used 'broker_scheme' for now but I'm not wedded to that. 'broker_protocol' would have been more consistent with what we use elsewhere, but 'protocol' was never an ideal choice there.