### PR TITLE
constraints: remove limit of two array elements

### DIFF
--- a/APIs/schemas/constraints-schema.json
+++ b/APIs/schemas/constraints-schema.json
@@ -3,7 +3,6 @@
   "type": "array",
   "description": "Used to express the dynamic constraints on transport parameters. These constraints may be set and changed at run time. Parameters must also conform with constraints inferred from the specification. Every transport parameter must have an entry, even if it is only an empty object.",
   "title": "Constraints",
-  "maxitems": 2,
   "items": {
     "anyOf":[
       {


### PR DESCRIPTION
Adding this as a discussion point relating to #70 

Removing this limit would be less painful if done prior to v1.1. It would require a docs note adding for any servers which implement multiple versions to make clear that for the RTP transport type only, more than two legs isn't supported before v1.1.

This would allow a WebSocket Sender to list many connection_uris for different interfaces. The issue of what to do with any parameters which get duplicated between 'legs' as a result remains, but this would at least remove a blocker to some future uses.