### PR TITLE
[v1.1 review] Add "format": "uri" constraint to WebSocket transport "connection_uri"

### DIFF
--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -18,6 +18,7 @@
             ],
             "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. A null value indicates that the receiver has not yet been configured.",
             "anyOf": [{
+                "format": "uri",
                 "pattern": "^wss?:\/\/.*"
               },
               {

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -21,6 +21,7 @@
                 "pattern": "^auto$"
               },
               {
+                "format": "uri",
                 "pattern": "^wss?:\/\/.*"
               },
               {


### PR DESCRIPTION
Note that IS-04 Query API subscription `"ws_href"` already has this `format` constraint, but don't have the `pattern` constraint for the scheme already used here.