### PR TITLE
[v1.1 review] Restructuring of sender/receiver stage/response transport_parameters schemas

### DIFF
--- a/APIs/schemas/constraints-schema.json
+++ b/APIs/schemas/constraints-schema.json
@@ -1,19 +1,24 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "array",
   "description": "Used to express the dynamic constraints on transport parameters. These constraints may be set and changed at run time. Parameters must also conform with constraints inferred from the specification. Every transport parameter must have an entry, even if it is only an empty object.",
   "title": "Constraints",
-  "items": {
-    "anyOf":[
-      {
+  "anyOf": [{
+      "type": "array",
+      "items": {
         "$ref": "constraints-schema-rtp.json"
-      },
-      {
+      }
+    },
+    {
+      "type": "array",
+      "items": {
         "$ref": "constraints-schema-websocket.json"
-      },
-      {
+      }
+    },
+    {
+      "type": "array",
+      "items": {
         "$ref": "constraints-schema-mqtt.json"
       }
-    ]
-  }
+    }
+  ]
 }

--- a/APIs/schemas/receiver-response-schema.json
+++ b/APIs/schemas/receiver-response-schema.json
@@ -31,20 +31,7 @@
       "$ref": "receiver-transport-file.json"
     },
     "transport_params": {
-      "description": "Transport-specific parameters",
-      "anyOf": [{
-          "$ref": "receiver_transport_params_rtp.json"
-        },
-        {
-          "$ref": "receiver_transport_params_dash.json"
-        },
-        {
-          "$ref": "receiver_transport_params_websocket.json"
-        },
-        {
-          "$ref": "receiver_transport_params_mqtt.json"
-        }
-      ]
+      "$ref": "receiver_transport_params.json"
     }
   }
 }

--- a/APIs/schemas/receiver-stage-schema.json
+++ b/APIs/schemas/receiver-stage-schema.json
@@ -24,20 +24,7 @@
       "$ref": "receiver-transport-file.json"
     },
     "transport_params": {
-      "description": "Transport-specific parameters. If this parameter is included in a client request it must include the same number of array elements (or 'legs') as specified in the constraints. If no changes are required to a specific leg it must be included as an empty object ({}).",
-      "anyOf": [{
-          "$ref": "receiver_transport_params_rtp.json"
-        },
-        {
-          "$ref": "receiver_transport_params_dash.json"
-        },
-        {
-          "$ref": "receiver_transport_params_websocket.json"
-        },
-        {
-          "$ref": "receiver_transport_params_mqtt.json"
-        }
-      ]
+      "$ref": "receiver_transport_params.json"
     }
   }
 }

--- a/APIs/schemas/receiver_transport_params.json
+++ b/APIs/schemas/receiver_transport_params.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Transport-specific parameters. If this parameter is included in a client request it must include the same number of array elements (or 'legs') as specified in the constraints. If no changes are required to a specific leg it must be included as an empty object ({}).",
+  "title": "Receiver Transport Parameters",
+  "anyOf": [{
+      "type": "array",
+      "items": {
+        "$ref": "receiver_transport_params_rtp.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "receiver_transport_params_dash.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "receiver_transport_params_websocket.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "receiver_transport_params_mqtt.json"
+      }
+    }
+  ]
+}

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -2,85 +2,82 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes MQTT Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. MQTT Receivers must support all parameters in this schema.",
   "title": "MQTT Receiver Transport Parameters",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "title": "Receiver Input",
-    "allOf": [
-      { "$ref": "receiver_transport_params_ext.json" },
-      {
-        "type": "object",
-        "properties": {
-          "source_host": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Receiver has not yet been configured.",
-            "anyOf": [{
-                "pattern": "^auto$"
-              },
-              {
-                "format": "hostname"
-              },
-              {
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "source_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "Source port for MQTT traffic. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "broker_protocol": {
-            "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
-            "enum": [
-              "auto",
-              "mqtt",
-              "secure-mqtt"
-            ]
-          },
-          "broker_authorization": {
-            "type": [
-              "string",
-              "boolean"
-            ],
-            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
-            "enum": [
-              "auto",
-              true,
-              false
-            ]
-          },
-          "broker_topic": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The topic which MQTT messages will be received from via the MQTT broker. A null value indicates that the Receiver has not yet been configured."
-          },
-          "connection_status_broker_topic": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The topic used for MQTT status messages such as MQTT Last Will which are received via the MQTT broker. A null value indicates that the Receiver has not yet been configured, or is not using a connection status topic."
-          }
+  "type": "object",
+  "title": "Receiver Input",
+  "allOf": [
+    { "$ref": "receiver_transport_params_ext.json" },
+    {
+      "type": "object",
+      "properties": {
+        "source_host": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Receiver has not yet been configured.",
+          "anyOf": [{
+              "pattern": "^auto$"
+            },
+            {
+              "format": "hostname"
+            },
+            {
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "source_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Source port for MQTT traffic. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "broker_protocol": {
+          "type": "string",
+          "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
+          "enum": [
+            "auto",
+            "mqtt",
+            "secure-mqtt"
+          ]
+        },
+        "broker_authorization": {
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
+          "enum": [
+            "auto",
+            true,
+            false
+          ]
+        },
+        "broker_topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The topic which MQTT messages will be received from via the MQTT broker. A null value indicates that the Receiver has not yet been configured."
+        },
+        "connection_status_broker_topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The topic used for MQTT status messages such as MQTT Last Will which are received via the MQTT broker. A null value indicates that the Receiver has not yet been configured, or is not using a connection status topic."
         }
       }
-    ]
-  }
+    }
+  ]
 }

--- a/APIs/schemas/receiver_transport_params_rtp.json
+++ b/APIs/schemas/receiver_transport_params_rtp.json
@@ -2,154 +2,151 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes RTP Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. Receivers must support at least the `source_ip`, `interface_ip`, `rtp_enabled` and `destination_port` parameters, and must support the `multicast_ip` parameter if they are capable of multicast operation. Receivers supporting FEC and/or RTCP must support parameters prefixed with `fec` and `rtcp` respectively.",
   "title": "RTP Receiver Transport Parameters",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "title": "Receiver Input",
-    "allOf": [
-      { "$ref": "receiver_transport_params_ext.json" },
-      {
-        "type": "object",
-        "properties": {
-          "source_ip": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "multicast_ip": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "IP multicast group address used in multicast operation only. Should be set to null during unicast operation. A null value indicates the parameter has not been configured, or the receiver is operating in unicast mode.",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "interface_ip": {
-            "type": "string",
-            "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTP packets (auto = 5004 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "fec_enabled": {
-            "type": "boolean",
-            "description": "FEC on/off"
-          },
-          "fec_destination_ip": {
-            "type": "string",
-            "description": "May be used if NAT is being used at the destination (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "fec_mode": {
-            "type": "string",
-            "description": "forward error correction mode to apply. (auto = highest available number of dimensions by default)",
-            "enum": [
-              "auto",
-              "1D",
-              "2D"
-            ]
-          },
-          "fec1D_destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "fec2D_destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "rtcp_destination_ip": {
-            "type": "string",
-            "description": "Destination IP address of RTCP packets (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "rtcp_enabled": {
-            "type": "boolean",
-            "description": "RTCP on/off"
-          },
-          "rtcp_destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "rtp_enabled": {
-            "type": "boolean",
-            "description": "RTP reception active/inactive"
-          }
+  "type": "object",
+  "title": "Receiver Input",
+  "allOf": [
+    { "$ref": "receiver_transport_params_ext.json" },
+    {
+      "type": "object",
+      "properties": {
+        "source_ip": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "multicast_ip": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "IP multicast group address used in multicast operation only. Should be set to null during unicast operation. A null value indicates the parameter has not been configured, or the receiver is operating in unicast mode.",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "interface_ip": {
+          "type": "string",
+          "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTP packets (auto = 5004 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "fec_enabled": {
+          "type": "boolean",
+          "description": "FEC on/off"
+        },
+        "fec_destination_ip": {
+          "type": "string",
+          "description": "May be used if NAT is being used at the destination (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "fec_mode": {
+          "type": "string",
+          "description": "forward error correction mode to apply. (auto = highest available number of dimensions by default)",
+          "enum": [
+            "auto",
+            "1D",
+            "2D"
+          ]
+        },
+        "fec1D_destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "fec2D_destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "rtcp_destination_ip": {
+          "type": "string",
+          "description": "Destination IP address of RTCP packets (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "rtcp_enabled": {
+          "type": "boolean",
+          "description": "RTCP on/off"
+        },
+        "rtcp_destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "rtp_enabled": {
+          "type": "boolean",
+          "description": "RTP reception active/inactive"
         }
       }
-    ]
-  }
+    }
+  ]
 }

--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -2,43 +2,40 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes WebSocket Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. Receivers must support at least the `connection_uri` parameter.",
   "title": "WebSocket Receiver Transport Parameters",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "title": "Receiver Input",
-    "allOf": [
-      { "$ref": "receiver_transport_params_ext.json" },
-      {
-        "type": "object",
-        "properties": {
-          "connection_uri": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. A null value indicates that the receiver has not yet been configured.",
-            "anyOf": [{
-                "pattern": "^wss?:\/\/.*"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "connection_authorization": {
-            "type": [
-              "string",
-              "boolean"
-            ],
-            "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on its own internal configuration.",
-            "enum": [
-              "auto",
-              true,
-              false
-            ]
-          }
+  "type": "object",
+  "title": "Receiver Input",
+  "allOf": [
+    { "$ref": "receiver_transport_params_ext.json" },
+    {
+      "type": "object",
+      "properties": {
+        "connection_uri": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. A null value indicates that the receiver has not yet been configured.",
+          "anyOf": [{
+              "pattern": "^wss?:\/\/.*"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connection_authorization": {
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on its own internal configuration.",
+          "enum": [
+            "auto",
+            true,
+            false
+          ]
         }
       }
-    ]
-  }
+    }
+  ]
 }

--- a/APIs/schemas/sender-response-schema.json
+++ b/APIs/schemas/sender-response-schema.json
@@ -27,20 +27,7 @@
       "$ref": "activation-response-schema.json"
     },
     "transport_params": {
-      "description": "Transport-specific parameters",
-      "anyOf": [{
-          "$ref": "sender_transport_params_rtp.json"
-        },
-        {
-          "$ref": "sender_transport_params_dash.json"
-        },
-        {
-          "$ref": "sender_transport_params_websocket.json"
-        },
-        {
-          "$ref": "sender_transport_params_mqtt.json"
-        }
-      ]
+      "$ref": "sender_transport_params.json"
     }
   }
 }

--- a/APIs/schemas/sender-stage-schema.json
+++ b/APIs/schemas/sender-stage-schema.json
@@ -21,20 +21,7 @@
       "$ref": "activation-schema.json"
     },
     "transport_params": {
-      "description": "Transport-specific parameters. If this parameter is included in a client request it must include the same number of array elements (or 'legs') as specified in the constraints. If no changes are required to a specific leg it must be included as an empty object ({}).",
-      "anyOf": [{
-          "$ref": "sender_transport_params_rtp.json"
-        },
-        {
-          "$ref": "sender_transport_params_dash.json"
-        },
-        {
-          "$ref": "sender_transport_params_websocket.json"
-        },
-        {
-          "$ref": "sender_transport_params_mqtt.json"
-        }
-      ]
+      "$ref": "sender_transport_params.json"
     }
   }
 }

--- a/APIs/schemas/sender_transport_params.json
+++ b/APIs/schemas/sender_transport_params.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Transport-specific parameters. If this parameter is included in a client request it must include the same number of array elements (or 'legs') as specified in the constraints. If no changes are required to a specific leg it must be included as an empty object ({}).",
+  "title": "Sender Transport Parameters",
+  "anyOf": [{
+      "type": "array",
+      "items": {
+        "$ref": "sender_transport_params_rtp.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "sender_transport_params_dash.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "sender_transport_params_websocket.json"
+      }
+    },
+    {
+      "type": "array",
+      "items": {
+        "$ref": "sender_transport_params_mqtt.json"
+      }
+    }
+  ]
+}

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -2,85 +2,82 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes MQTT Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. MQTT Senders must support all properties in this schema.",
   "title": "MQTT Sender Transport Parameters",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "title": "Sender Output",
-    "allOf": [
-      { "$ref": "sender_transport_params_ext.json" },
-      {
-        "type": "object",
-        "properties": {
-          "destination_host": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Sender has not yet been configured.",
-            "anyOf": [{
-                "pattern": "^auto$"
-              },
-              {
-                "format": "hostname"
-              },
-              {
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "Destination port for MQTT traffic. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "broker_protocol": {
-            "type": "string",
-            "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
-            "enum": [
-              "auto",
-              "mqtt",
-              "secure-mqtt"
-            ]
-          },
-          "broker_authorization": {
-            "type": [
-              "string",
-              "boolean"
-            ],
-            "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
-            "enum": [
-              "auto",
-              true,
-              false
-            ]
-          },
-          "broker_topic": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The topic which MQTT messages will be sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured."
-          },
-          "connection_status_broker_topic": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "The topic which MQTT status messages such as MQTT Last Will are sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured, or is not using a connection status topic."
-          }
+  "type": "object",
+  "title": "Sender Output",
+  "allOf": [
+    { "$ref": "sender_transport_params_ext.json" },
+    {
+      "type": "object",
+      "properties": {
+        "destination_host": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Sender has not yet been configured.",
+          "anyOf": [{
+              "pattern": "^auto$"
+            },
+            {
+              "format": "hostname"
+            },
+            {
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "Destination port for MQTT traffic. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "broker_protocol": {
+          "type": "string",
+          "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
+          "enum": [
+            "auto",
+            "mqtt",
+            "secure-mqtt"
+          ]
+        },
+        "broker_authorization": {
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
+          "enum": [
+            "auto",
+            true,
+            false
+          ]
+        },
+        "broker_topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The topic which MQTT messages will be sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured."
+        },
+        "connection_status_broker_topic": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The topic which MQTT status messages such as MQTT Last Will are sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured, or is not using a connection status topic."
         }
       }
-    ]
-  }
+    }
+  ]
 }

--- a/APIs/schemas/sender_transport_params_rtp.json
+++ b/APIs/schemas/sender_transport_params_rtp.json
@@ -2,193 +2,190 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes RTP Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. As a minimum all senders must support `source_ip`, `destination_ip`, `source_port`, `rtp_enabled` and `destination_port`. Senders supporting FEC and/or RTCP must support parameters prefixed with `fec` and `rtcp` respectively.",
   "title": "RTP Sender Transport Parameters",
-  "type": "array",
-  "items": {
     "type": "object",
-    "title": "Sender Output",
-    "allOf": [
-      { "$ref": "sender_transport_params_ext.json" },
-      {
-        "type": "object",
-        "properties": {
-          "source_ip": {
-            "type": "string",
-            "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "destination_ip": {
-            "type": "string",
-            "description": "IP address to which RTP packets will be sent. If auto is set the sender should select a multicast address to send to itself. For example it may implement MADCAP (RFC 2730), ZMAAP, or be allocated address by some other system responsible for co-ordination multicast address use.",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "source_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "source port for RTP packets (auto = 5004 by default)",
-            "minimum": 0,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTP packets (auto = 5004 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "fec_enabled": {
-            "type": "boolean",
-            "description": "FEC on/off"
-          },
-          "fec_destination_ip": {
-            "type": "string",
-            "description": "May be used if NAT is being used at the destination (auto = destination_ip by default)",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "fec_type": {
-            "type": "string",
-            "description": "forward error correction mode to apply",
-            "enum": [
-              "XOR",
-              "Reed-Solomon"
-            ]
-          },
-          "fec_mode": {
-            "type": "string",
-            "description": "forward error correction mode to apply",
-            "enum": [
-              "1D",
-              "2D"
-            ]
-          },
-          "fec_block_width": {
-            "type": "integer",
-            "description": "width of block over which FEC is calculated in packets",
-            "minimum": 4,
-            "maximum": 200
-          },
-          "fec_block_height": {
-            "type": "integer",
-            "description": "height of block over which FEC is calculated in packets",
-            "minimum": 4,
-            "maximum": 200
-          },
-          "fec1D_destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "fec2D_destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "fec1D_source_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "source port for RTP FEC packets (auto = RTP source_port + 2 by default)",
-            "minimum": 0,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "fec2D_source_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "source port for RTP FEC packets (auto = RTP source_port + 4 by default)",
-            "minimum": 0,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "rtcp_enabled": {
-            "type": "boolean",
-            "description": "rtcp on/off"
-          },
-          "rtcp_destination_ip": {
-            "type": "string",
-            "description": "IP address to which RTCP packets will be sent (auto = same as RTP destination_ip by default)",
-            "anyOf": [{
-                "format": "ipv4"
-              },
-              {
-                "format": "ipv6"
-              },
-              {
-                "pattern": "^auto$"
-              }
-            ]
-          },
-          "rtcp_destination_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
-            "minimum": 1,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "rtcp_source_port": {
-            "type": [
-              "integer",
-              "string"
-            ],
-            "description": "source port for RTCP packets (auto = RTP source_port + 1 by default)",
-            "minimum": 0,
-            "maximum": 65535,
-            "pattern": "^auto$"
-          },
-          "rtp_enabled": {
-            "type": "boolean",
-            "description": "RTP transmission active/inactive"
-          }
+  "title": "Sender Output",
+  "allOf": [
+    { "$ref": "sender_transport_params_ext.json" },
+    {
+      "type": "object",
+      "properties": {
+        "source_ip": {
+          "type": "string",
+          "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "destination_ip": {
+          "type": "string",
+          "description": "IP address to which RTP packets will be sent. If auto is set the sender should select a multicast address to send to itself. For example it may implement MADCAP (RFC 2730), ZMAAP, or be allocated address by some other system responsible for co-ordination multicast address use.",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "source_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "source port for RTP packets (auto = 5004 by default)",
+          "minimum": 0,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTP packets (auto = 5004 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "fec_enabled": {
+          "type": "boolean",
+          "description": "FEC on/off"
+        },
+        "fec_destination_ip": {
+          "type": "string",
+          "description": "May be used if NAT is being used at the destination (auto = destination_ip by default)",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "fec_type": {
+          "type": "string",
+          "description": "forward error correction mode to apply",
+          "enum": [
+            "XOR",
+            "Reed-Solomon"
+          ]
+        },
+        "fec_mode": {
+          "type": "string",
+          "description": "forward error correction mode to apply",
+          "enum": [
+            "1D",
+            "2D"
+          ]
+        },
+        "fec_block_width": {
+          "type": "integer",
+          "description": "width of block over which FEC is calculated in packets",
+          "minimum": 4,
+          "maximum": 200
+        },
+        "fec_block_height": {
+          "type": "integer",
+          "description": "height of block over which FEC is calculated in packets",
+          "minimum": 4,
+          "maximum": 200
+        },
+        "fec1D_destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "fec2D_destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "fec1D_source_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "source port for RTP FEC packets (auto = RTP source_port + 2 by default)",
+          "minimum": 0,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "fec2D_source_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "source port for RTP FEC packets (auto = RTP source_port + 4 by default)",
+          "minimum": 0,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "rtcp_enabled": {
+          "type": "boolean",
+          "description": "rtcp on/off"
+        },
+        "rtcp_destination_ip": {
+          "type": "string",
+          "description": "IP address to which RTCP packets will be sent (auto = same as RTP destination_ip by default)",
+          "anyOf": [{
+              "format": "ipv4"
+            },
+            {
+              "format": "ipv6"
+            },
+            {
+              "pattern": "^auto$"
+            }
+          ]
+        },
+        "rtcp_destination_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
+          "minimum": 1,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "rtcp_source_port": {
+          "type": [
+            "integer",
+            "string"
+          ],
+          "description": "source port for RTCP packets (auto = RTP source_port + 1 by default)",
+          "minimum": 0,
+          "maximum": 65535,
+          "pattern": "^auto$"
+        },
+        "rtp_enabled": {
+          "type": "boolean",
+          "description": "RTP transmission active/inactive"
         }
       }
-    ]
-  }
+    }
+  ]
 }

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -2,46 +2,43 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "Describes WebSocket Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. All senders must support `connection_uri`.",
   "title": "WebSocket Sender Transport Parameters",
-  "type": "array",
-  "items": {
-    "type": "object",
-    "title": "Sender Output",
-    "allOf": [
-      { "$ref": "sender_transport_params_ext.json" },
-      {
-        "type": "object",
-        "properties": {
-          "connection_uri": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
-            "anyOf": [{
-                "pattern": "^auto$"
-              },
-              {
-                "pattern": "^wss?:\/\/.*"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "connection_authorization": {
-            "type": [
-              "string",
-              "boolean"
-            ],
-            "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on its own internal configuration.",
-            "enum": [
-              "auto",
-              true,
-              false
-            ]
-          }
+  "type": "object",
+  "title": "Sender Output",
+  "allOf": [
+    { "$ref": "sender_transport_params_ext.json" },
+    {
+      "type": "object",
+      "properties": {
+        "connection_uri": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
+          "anyOf": [{
+              "pattern": "^auto$"
+            },
+            {
+              "pattern": "^wss?:\/\/.*"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "connection_authorization": {
+          "type": [
+            "string",
+            "boolean"
+          ],
+          "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on its own internal configuration.",
+          "enum": [
+            "auto",
+            true,
+            false
+          ]
         }
       }
-    ]
-  }
+    }
+  ]
 }


### PR DESCRIPTION
… to simplify the 4 stage/response schemas and each of the transport params schemas, by matching the structure of constraints-schema.

(Actually, [constraints-schema.json](https://github.com/AMWA-TV/nmos-device-connection-management/blob/87833f2d7706ba39963080525342a9bd54c6e0bb/APIs/schemas/constraints-schema.json) as currently written, allows each 'leg' to be a different transport constraints. The sender_transport_params.json and receiver_transport_params.json introduced by this PR currently use a more verbose style to avoid that, but a consistent approach should be used between all three.)