### PR TITLE
Refactor transport params schemas in order to prevent invalid property values passing unintentionally

### DIFF
--- a/APIs/schemas/receiver_transport_params_ext.json
+++ b/APIs/schemas/receiver_transport_params_ext.json
@@ -1,17 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Describes external Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "description": "Describes external Receiver transport parameters defined in other AMWA IS specifications. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
   "title": "External Receiver Transport Parameters",
-  "type": "object",
-  "patternProperties": {
-    "^ext_[a-zA-Z0-9_]+$":{
-      "description": "Properties defined in other AMWA IS specifications",
-      "type":[
-        "string",
-        "boolean",
-        "null",
-        "number"
-      ]
-    }
-  }
+  "type":[
+    "string",
+    "boolean",
+    "null",
+    "number"
+  ]
 }

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -4,80 +4,80 @@
   "title": "MQTT Receiver Transport Parameters",
   "type": "object",
   "title": "Receiver Input",
-  "allOf": [
-    { "$ref": "receiver_transport_params_ext.json" },
-    {
-      "type": "object",
-      "properties": {
-        "source_host": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Receiver has not yet been configured.",
-          "anyOf": [{
-              "pattern": "^auto$"
-            },
-            {
-              "format": "hostname"
-            },
-            {
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "source_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "Source port for MQTT traffic. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
-          "minimum": 1,
-          "maximum": 65535,
+  "properties": {
+    "source_host": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Receiver has not yet been configured.",
+      "anyOf": [{
           "pattern": "^auto$"
         },
-        "broker_protocol": {
-          "type": "string",
-          "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
-          "enum": [
-            "auto",
-            "mqtt",
-            "secure-mqtt"
-          ]
+        {
+          "format": "hostname"
         },
-        "broker_authorization": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
-          "enum": [
-            "auto",
-            true,
-            false
-          ]
+        {
+          "format": "ipv4"
         },
-        "broker_topic": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "The topic which MQTT messages will be received from via the MQTT broker. A null value indicates that the Receiver has not yet been configured."
+        {
+          "format": "ipv6"
         },
-        "connection_status_broker_topic": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "The topic used for MQTT status messages such as MQTT Last Will which are received via the MQTT broker. A null value indicates that the Receiver has not yet been configured, or is not using a connection status topic."
+        {
+          "type": "null"
         }
-      }
+      ]
+    },
+    "source_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "Source port for MQTT traffic. If the parameter is set to auto the Receiver should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "broker_protocol": {
+      "type": "string",
+      "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Receiver should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
+      "enum": [
+        "auto",
+        "mqtt",
+        "secure-mqtt"
+      ]
+    },
+    "broker_authorization": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
+      "enum": [
+        "auto",
+        true,
+        false
+      ]
+    },
+    "broker_topic": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The topic which MQTT messages will be received from via the MQTT broker. A null value indicates that the Receiver has not yet been configured."
+    },
+    "connection_status_broker_topic": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The topic used for MQTT status messages such as MQTT Last Will which are received via the MQTT broker. A null value indicates that the Receiver has not yet been configured, or is not using a connection status topic."
     }
-  ]
+  },
+  "patternProperties": {
+    "^ext_[a-zA-Z0-9_]+$": {
+      "$ref": "receiver_transport_params_ext.json"
+    }
+  },
+  "additionalProperties": false
 }

--- a/APIs/schemas/receiver_transport_params_rtp.json
+++ b/APIs/schemas/receiver_transport_params_rtp.json
@@ -4,149 +4,149 @@
   "title": "RTP Receiver Transport Parameters",
   "type": "object",
   "title": "Receiver Input",
-  "allOf": [
-    { "$ref": "receiver_transport_params_ext.json" },
-    {
-      "type": "object",
-      "properties": {
-        "source_ip": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "type": "null"
-            }
-          ]
+  "properties": {
+    "source_ip": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
+      "anyOf": [{
+          "format": "ipv4"
         },
-        "multicast_ip": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "IP multicast group address used in multicast operation only. Should be set to null during unicast operation. A null value indicates the parameter has not been configured, or the receiver is operating in unicast mode.",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "type": "null"
-            }
-          ]
+        {
+          "format": "ipv6"
         },
-        "interface_ip": {
-          "type": "string",
-          "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
-        },
-        "destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTP packets (auto = 5004 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "fec_enabled": {
-          "type": "boolean",
-          "description": "FEC on/off"
-        },
-        "fec_destination_ip": {
-          "type": "string",
-          "description": "May be used if NAT is being used at the destination (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
-        },
-        "fec_mode": {
-          "type": "string",
-          "description": "forward error correction mode to apply. (auto = highest available number of dimensions by default)",
-          "enum": [
-            "auto",
-            "1D",
-            "2D"
-          ]
-        },
-        "fec1D_destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "fec2D_destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "rtcp_destination_ip": {
-          "type": "string",
-          "description": "Destination IP address of RTCP packets (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
-        },
-        "rtcp_enabled": {
-          "type": "boolean",
-          "description": "RTCP on/off"
-        },
-        "rtcp_destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "rtp_enabled": {
-          "type": "boolean",
-          "description": "RTP reception active/inactive"
+        {
+          "type": "null"
         }
-      }
+      ]
+    },
+    "multicast_ip": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "IP multicast group address used in multicast operation only. Should be set to null during unicast operation. A null value indicates the parameter has not been configured, or the receiver is operating in unicast mode.",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "interface_ip": {
+      "type": "string",
+      "description": "IP address of the network interface the receiver should use. The receiver should provide an enum in the constraints endpoint, which should contain the available interface addresses. If set to auto in multicast mode the receiver should determine which interface to use for itself, for example by using the routing tables. The behaviour of auto is undefined in unicast mode, and controllers should supply a specific interface address.",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "pattern": "^auto$"
+        }
+      ]
+    },
+    "destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTP packets (auto = 5004 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "fec_enabled": {
+      "type": "boolean",
+      "description": "FEC on/off"
+    },
+    "fec_destination_ip": {
+      "type": "string",
+      "description": "May be used if NAT is being used at the destination (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "pattern": "^auto$"
+        }
+      ]
+    },
+    "fec_mode": {
+      "type": "string",
+      "description": "forward error correction mode to apply. (auto = highest available number of dimensions by default)",
+      "enum": [
+        "auto",
+        "1D",
+        "2D"
+      ]
+    },
+    "fec1D_destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "fec2D_destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "rtcp_destination_ip": {
+      "type": "string",
+      "description": "Destination IP address of RTCP packets (auto = multicast_ip (multicast mode) or interface_ip (unicast mode) by default)",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "pattern": "^auto$"
+        }
+      ]
+    },
+    "rtcp_enabled": {
+      "type": "boolean",
+      "description": "RTCP on/off"
+    },
+    "rtcp_destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "rtp_enabled": {
+      "type": "boolean",
+      "description": "RTP reception active/inactive"
     }
-  ]
+  },
+  "patternProperties": {
+    "^ext_[a-zA-Z0-9_]+$": {
+      "$ref": "receiver_transport_params_ext.json"
+    }
+  },
+  "additionalProperties": false
 }

--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -4,39 +4,39 @@
   "title": "WebSocket Receiver Transport Parameters",
   "type": "object",
   "title": "Receiver Input",
-  "allOf": [
-    { "$ref": "receiver_transport_params_ext.json" },
-    {
-      "type": "object",
-      "properties": {
-        "connection_uri": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. A null value indicates that the receiver has not yet been configured.",
-          "anyOf": [{
-              "format": "uri",
-              "pattern": "^wss?:\/\/.*"
-            },
-            {
-              "type": "null"
-            }
-          ]
+  "properties": {
+    "connection_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. A null value indicates that the receiver has not yet been configured.",
+      "anyOf": [{
+          "format": "uri",
+          "pattern": "^wss?:\/\/.*"
         },
-        "connection_authorization": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on its own internal configuration.",
-          "enum": [
-            "auto",
-            true,
-            false
-          ]
+        {
+          "type": "null"
         }
-      }
+      ]
+    },
+    "connection_authorization": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Receiver should establish for itself whether authorization should be used, based on its own internal configuration.",
+      "enum": [
+        "auto",
+        true,
+        false
+      ]
     }
-  ]
+  },
+  "patternProperties": {
+    "^ext_[a-zA-Z0-9_]+$": {
+      "$ref": "receiver_transport_params_ext.json"
+    }
+  },
+  "additionalProperties": false
 }

--- a/APIs/schemas/sender_transport_params_ext.json
+++ b/APIs/schemas/sender_transport_params_ext.json
@@ -1,17 +1,11 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Describes external Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
+  "description": "Describes external Sender transport parameters defined in other AMWA IS specifications. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint.",
   "title": "External Sender Transport Parameters",
-  "type": "object",
-  "patternProperties": {
-    "^ext_[a-zA-Z0-9_]+$":{
-      "description": "Properties defined in other AMWA IS specifications",
-      "type":[
-        "string",
-        "boolean",
-        "null",
-        "number"
-      ]
-    }
-  }
+  "type":[
+    "string",
+    "boolean",
+    "null",
+    "number"
+  ]
 }

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -4,80 +4,80 @@
   "title": "MQTT Sender Transport Parameters",
   "type": "object",
   "title": "Sender Output",
-  "allOf": [
-    { "$ref": "sender_transport_params_ext.json" },
-    {
-      "type": "object",
-      "properties": {
-        "destination_host": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Sender has not yet been configured.",
-          "anyOf": [{
-              "pattern": "^auto$"
-            },
-            {
-              "format": "hostname"
-            },
-            {
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "Destination port for MQTT traffic. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
-          "minimum": 1,
-          "maximum": 65535,
+  "properties": {
+    "destination_host": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Hostname or IP hosting the MQTT broker. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration. A null value indicates that the Sender has not yet been configured.",
+      "anyOf": [{
           "pattern": "^auto$"
         },
-        "broker_protocol": {
-          "type": "string",
-          "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
-          "enum": [
-            "auto",
-            "mqtt",
-            "secure-mqtt"
-          ]
+        {
+          "format": "hostname"
         },
-        "broker_authorization": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
-          "enum": [
-            "auto",
-            true,
-            false
-          ]
+        {
+          "format": "ipv4"
         },
-        "broker_topic": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "The topic which MQTT messages will be sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured."
+        {
+          "format": "ipv6"
         },
-        "connection_status_broker_topic": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "The topic which MQTT status messages such as MQTT Last Will are sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured, or is not using a connection status topic."
+        {
+          "type": "null"
         }
-      }
+      ]
+    },
+    "destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "Destination port for MQTT traffic. If the parameter is set to auto the Sender should establish for itself which broker it should use, based on a discovery mechanism or its own internal configuration.",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "broker_protocol": {
+      "type": "string",
+      "description": "Indication of whether TLS is used for communication with the broker. 'mqtt' indicates operation without TLS, and 'secure-mqtt' indicates use of TLS. If the parameter is set to auto the Sender should establish for itself which protocol it should use, based on a discovery mechanism or its own internal configuration.",
+      "enum": [
+        "auto",
+        "mqtt",
+        "secure-mqtt"
+      ]
+    },
+    "broker_authorization": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "description": "Indication of whether authorization is used for communication with the broker. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on a discovery mechanism or its own internal configuration.",
+      "enum": [
+        "auto",
+        true,
+        false
+      ]
+    },
+    "broker_topic": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The topic which MQTT messages will be sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured."
+    },
+    "connection_status_broker_topic": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The topic which MQTT status messages such as MQTT Last Will are sent to on the MQTT broker. A null value indicates that the Sender has not yet been configured, or is not using a connection status topic."
     }
-  ]
+  },
+  "patternProperties": {
+    "^ext_[a-zA-Z0-9_]+$": {
+      "$ref": "sender_transport_params_ext.json"
+    }
+  },
+  "additionalProperties": false
 }

--- a/APIs/schemas/sender_transport_params_rtp.json
+++ b/APIs/schemas/sender_transport_params_rtp.json
@@ -4,188 +4,188 @@
   "title": "RTP Sender Transport Parameters",
     "type": "object",
   "title": "Sender Output",
-  "allOf": [
-    { "$ref": "sender_transport_params_ext.json" },
-    {
-      "type": "object",
-      "properties": {
-        "source_ip": {
-          "type": "string",
-          "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
+  "properties": {
+    "source_ip": {
+      "type": "string",
+      "description": "IP address from which RTP packets will be sent (IP address of interface bound to this output). The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration.",
+      "anyOf": [{
+          "format": "ipv4"
         },
-        "destination_ip": {
-          "type": "string",
-          "description": "IP address to which RTP packets will be sent. If auto is set the sender should select a multicast address to send to itself. For example it may implement MADCAP (RFC 2730), ZMAAP, or be allocated address by some other system responsible for co-ordination multicast address use.",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
+        {
+          "format": "ipv6"
         },
-        "source_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "source port for RTP packets (auto = 5004 by default)",
-          "minimum": 0,
-          "maximum": 65535,
+        {
           "pattern": "^auto$"
-        },
-        "destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTP packets (auto = 5004 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "fec_enabled": {
-          "type": "boolean",
-          "description": "FEC on/off"
-        },
-        "fec_destination_ip": {
-          "type": "string",
-          "description": "May be used if NAT is being used at the destination (auto = destination_ip by default)",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
-        },
-        "fec_type": {
-          "type": "string",
-          "description": "forward error correction mode to apply",
-          "enum": [
-            "XOR",
-            "Reed-Solomon"
-          ]
-        },
-        "fec_mode": {
-          "type": "string",
-          "description": "forward error correction mode to apply",
-          "enum": [
-            "1D",
-            "2D"
-          ]
-        },
-        "fec_block_width": {
-          "type": "integer",
-          "description": "width of block over which FEC is calculated in packets",
-          "minimum": 4,
-          "maximum": 200
-        },
-        "fec_block_height": {
-          "type": "integer",
-          "description": "height of block over which FEC is calculated in packets",
-          "minimum": 4,
-          "maximum": 200
-        },
-        "fec1D_destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "fec2D_destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "fec1D_source_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "source port for RTP FEC packets (auto = RTP source_port + 2 by default)",
-          "minimum": 0,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "fec2D_source_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "source port for RTP FEC packets (auto = RTP source_port + 4 by default)",
-          "minimum": 0,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "rtcp_enabled": {
-          "type": "boolean",
-          "description": "rtcp on/off"
-        },
-        "rtcp_destination_ip": {
-          "type": "string",
-          "description": "IP address to which RTCP packets will be sent (auto = same as RTP destination_ip by default)",
-          "anyOf": [{
-              "format": "ipv4"
-            },
-            {
-              "format": "ipv6"
-            },
-            {
-              "pattern": "^auto$"
-            }
-          ]
-        },
-        "rtcp_destination_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
-          "minimum": 1,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "rtcp_source_port": {
-          "type": [
-            "integer",
-            "string"
-          ],
-          "description": "source port for RTCP packets (auto = RTP source_port + 1 by default)",
-          "minimum": 0,
-          "maximum": 65535,
-          "pattern": "^auto$"
-        },
-        "rtp_enabled": {
-          "type": "boolean",
-          "description": "RTP transmission active/inactive"
         }
-      }
+      ]
+    },
+    "destination_ip": {
+      "type": "string",
+      "description": "IP address to which RTP packets will be sent. If auto is set the sender should select a multicast address to send to itself. For example it may implement MADCAP (RFC 2730), ZMAAP, or be allocated address by some other system responsible for co-ordination multicast address use.",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "pattern": "^auto$"
+        }
+      ]
+    },
+    "source_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "source port for RTP packets (auto = 5004 by default)",
+      "minimum": 0,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTP packets (auto = 5004 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "fec_enabled": {
+      "type": "boolean",
+      "description": "FEC on/off"
+    },
+    "fec_destination_ip": {
+      "type": "string",
+      "description": "May be used if NAT is being used at the destination (auto = destination_ip by default)",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "pattern": "^auto$"
+        }
+      ]
+    },
+    "fec_type": {
+      "type": "string",
+      "description": "forward error correction mode to apply",
+      "enum": [
+        "XOR",
+        "Reed-Solomon"
+      ]
+    },
+    "fec_mode": {
+      "type": "string",
+      "description": "forward error correction mode to apply",
+      "enum": [
+        "1D",
+        "2D"
+      ]
+    },
+    "fec_block_width": {
+      "type": "integer",
+      "description": "width of block over which FEC is calculated in packets",
+      "minimum": 4,
+      "maximum": 200
+    },
+    "fec_block_height": {
+      "type": "integer",
+      "description": "height of block over which FEC is calculated in packets",
+      "minimum": 4,
+      "maximum": 200
+    },
+    "fec1D_destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTP Column FEC packets (auto = RTP destination_port + 2 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "fec2D_destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTP Row FEC packets (auto = RTP destination_port + 4 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "fec1D_source_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "source port for RTP FEC packets (auto = RTP source_port + 2 by default)",
+      "minimum": 0,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "fec2D_source_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "source port for RTP FEC packets (auto = RTP source_port + 4 by default)",
+      "minimum": 0,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "rtcp_enabled": {
+      "type": "boolean",
+      "description": "rtcp on/off"
+    },
+    "rtcp_destination_ip": {
+      "type": "string",
+      "description": "IP address to which RTCP packets will be sent (auto = same as RTP destination_ip by default)",
+      "anyOf": [{
+          "format": "ipv4"
+        },
+        {
+          "format": "ipv6"
+        },
+        {
+          "pattern": "^auto$"
+        }
+      ]
+    },
+    "rtcp_destination_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "destination port for RTCP packets (auto = RTP destination_port + 1 by default)",
+      "minimum": 1,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "rtcp_source_port": {
+      "type": [
+        "integer",
+        "string"
+      ],
+      "description": "source port for RTCP packets (auto = RTP source_port + 1 by default)",
+      "minimum": 0,
+      "maximum": 65535,
+      "pattern": "^auto$"
+    },
+    "rtp_enabled": {
+      "type": "boolean",
+      "description": "RTP transmission active/inactive"
     }
-  ]
+  },
+  "patternProperties": {
+    "^ext_[a-zA-Z0-9_]+$": {
+      "$ref": "sender_transport_params_ext.json"
+    }
+  },
+  "additionalProperties": false
 }

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -4,42 +4,42 @@
   "title": "WebSocket Sender Transport Parameters",
   "type": "object",
   "title": "Sender Output",
-  "allOf": [
-    { "$ref": "sender_transport_params_ext.json" },
-    {
-      "type": "object",
-      "properties": {
-        "connection_uri": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
-          "anyOf": [{
-              "pattern": "^auto$"
-            },
-            {
-              "format": "uri",
-              "pattern": "^wss?:\/\/.*"
-            },
-            {
-              "type": "null"
-            }
-          ]
+  "properties": {
+    "connection_uri": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "URI hosting the WebSocket server as defined in RFC 6455 Section 3. The sender should provide an enum in the constraints endpoint, which should contain the available interface addresses formatted as connection URIs. If the parameter is set to auto the sender should establish for itself which interface it should use, based on routing rules or its own internal configuration. A null value indicates that the sender has not yet been configured.",
+      "anyOf": [{
+          "pattern": "^auto$"
         },
-        "connection_authorization": {
-          "type": [
-            "string",
-            "boolean"
-          ],
-          "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on its own internal configuration.",
-          "enum": [
-            "auto",
-            true,
-            false
-          ]
+        {
+          "format": "uri",
+          "pattern": "^wss?:\/\/.*"
+        },
+        {
+          "type": "null"
         }
-      }
+      ]
+    },
+    "connection_authorization": {
+      "type": [
+        "string",
+        "boolean"
+      ],
+      "description": "Indication of whether authorization is required to make a connection. If the parameter is set to auto the Sender should establish for itself whether authorization should be used, based on its own internal configuration.",
+      "enum": [
+        "auto",
+        true,
+        false
+      ]
     }
-  ]
+  },
+  "patternProperties": {
+    "^ext_[a-zA-Z0-9_]+$": {
+      "$ref": "sender_transport_params_ext.json"
+    }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
Resolves #98.

Due to combination of `"anyOf"` in {sender|receiver}\_transport_params.json schemas, and lack of `"additionalProperties": false` and any `"required"` parameters in each {sender|receiver}\_transport_params_{mqtt|rtp|websocket}.json schema, invalid property values were actually being accepted.

Could have renamed / combined the {sender|receiver}\_transport_params_ext.json schemas, but this seems OK to me.

*Looks a lot worse in GitHub web diff than it is!*
