### PR TITLE
Consistently don't use section numbers in cross-refs

### DIFF
--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -48,7 +48,7 @@ The API provides a mechanism to modify settings for an individual Sender or Rece
 
 The API also provides a mechanism to modify settings for many Senders or Receivers at once which sit within the scope of the API implementation (typically contained by a Node or Device). This is referred to as the 'bulk' interface.
 
-The 'bulk' interface may be used to support specialist 'salvo' operations in capable Devices, as described in [4.0. Behaviour](4.0.%20Behaviour.md).
+The 'bulk' interface may be used to support specialist 'salvo' operations in capable Devices, as described in [Behaviour](4.0.%20Behaviour.md).
 
 ## API Interaction
 

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)_
 
 ## Conforming to Schemas
 
-When interacting with a Connection Management API, a client may assume the presence of a core set of attributes for each defined transport type. Other parameters may be defined by the specification, but are optional for implementations given that they may or may not implement a particular feature. Presence of these attributes in an implementation cannot be assumed and must be identified via the '/constraints' resource of a running Device. A list of core attributes, and attributes associated with particular features, is given in [4.1 Behaviour - RTP Transport Type](4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md) and further pages in section 4.
+When interacting with a Connection Management API, a client may assume the presence of a core set of attributes for each defined transport type. Other parameters may be defined by the specification, but are optional for implementations given that they may or may not implement a particular feature. Presence of these attributes in an implementation cannot be assumed and must be identified via the '/constraints' resource of a running Device. A list of core attributes, and attributes associated with particular features, is given in [Behaviour - RTP Transport Type](4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md) and further pages in the [Behaviour](4.0.%20Behaviour.md) section.
 
 For core attributes, individual APIs may still constrain their permitted values to a particular range or enumeration, so parsing the constraints is still recommended.
 

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -26,11 +26,11 @@ The associated 'href' is the URL of the Connection API base resource.
 
 Note as above that the API version is included in the 'type', and in the 'href'. Further control endpoints for the Connection Management API may be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
 
-More details about multi-version support can be found in [5.0. Upgrade Path](5.0.%20Upgrade%20Path.md).
+More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
 A given instance of the Connection Management API may offer control of multiple Devices in a Node from a single URI. Alternatively there may be multiple instances of the API on one Node, each corresponding to one Device. A separate 'control' endpoint for each Device's Connection Management instance must be advertised, even if the URI is the same.
 
-API implementations may list an 'href' with or without a trailing slash, provided that the trailing slash policy in [2.0. APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. In order to avoid cases of double slashes or missing slashes, clients are required to exercise caution when appending paths onto this 'href'.
+API implementations may list an 'href' with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. In order to avoid cases of double slashes or missing slashes, clients are required to exercise caution when appending paths onto this 'href'.
 
 ## Sender & Receiver IDs
 


### PR DESCRIPTION
... especially since no section numbers are displayed in the rendered docs. (This has been sitting in a Git stash for 6 months!)

Could be merged to v1.0.x also.