### PR TITLE
Clarify source_ip behaviour

### DIFF
--- a/APIs/schemas/receiver_transport_params_rtp.json
+++ b/APIs/schemas/receiver_transport_params_rtp.json
@@ -10,7 +10,7 @@
         "string",
         "null"
       ],
-      "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the receiver has not yet been configured, or in any-source multicast mode.",
+      "description": "Source IP address of RTP packets in unicast mode, source filter for source specific multicast. A null value indicates that the source IP address has not been configured in unicast mode, or the Receiver is in any-source multicast mode.",
       "anyOf": [{
           "format": "ipv4"
         },

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -113,7 +113,7 @@ a=rtpmap:99 h263-1998/90000
 ```json
 "transport_params": [
     {
-        "source_ip": "10.47.16.5",
+        "source_ip": null,
         "multicast_ip": null,
         "interface_ip": "10.46.16.34",
         "destination_port": 51372,
@@ -126,7 +126,7 @@ a=rtpmap:99 h263-1998/90000
 
 ```
 v=0
-o=- 1497010742 1497010742 IN IP4 172.29.226.24
+o=- 1497010742 1497010742 IN IP4 172.29.26.24
 s=SDP Example
 t=2873397496 2873404696
 m=video 5000 RTP/AVP 103
@@ -151,11 +151,11 @@ a=rtpmap:103 raw/90000
 
 ```
 v=0
-o=- 1497010742 1497010742 IN IP4 172.29.226.24
+o=- 1497010742 1497010742 IN IP4 172.29.26.24
 s=SDP Example
 t=2873397496 2873404696
 m=video 5000 RTP/AVP 103
-c=IN IP4 232.21.21.133/32
+c=IN IP4 239.21.21.133/32
 a=rtpmap:103 raw/90000
 ```
 
@@ -163,7 +163,7 @@ a=rtpmap:103 raw/90000
 "transport_params": [
     {
         "source_ip": null,
-        "multicast_ip": "232.21.21.133",
+        "multicast_ip": "239.21.21.133",
         "interface_ip": "auto",
         "destination_port": 5000,
         "rtp_enabled": true
@@ -179,7 +179,7 @@ Connection Management APIs supporting SMPTE 2022-5 must comply with RFC 6364 whe
 
 ```
 v=0
-o=ali 1122334455 1122334466 IN IP4 172.29.226.24
+o=ali 1122334455 1122334466 IN IP4 172.29.26.24
 s=FEC Framework Examples
 t=0 0
 a=group:FEC-FR S1 R1
@@ -197,7 +197,7 @@ a=mid:R1
 ```json
 "transport_params": [
     {
-        "source_ip": "172.29.226.24",
+        "source_ip": null,
         "multicast_ip": "233.252.0.1",
         "interface_ip": "auto",
         "destination_port": 30000,
@@ -344,7 +344,7 @@ Senders and Receivers supporting RTCP should comply with RFC 3605 when creating 
 
 ```
 v=0
-o=- 1497010742 1497010742 IN IP4 172.29.226.24
+o=- 1497010742 1497010742 IN IP4 172.29.26.24
 s=SDP Example
 t=2873397496 2873404696
 m=video 5000 RTP/AVP 103


### PR DESCRIPTION
The `source_ip` parameter should always be set based on the `source-filter` attribute, not the Origin (`o=`) line. The Origin unicast address may be a management IP address or obfuscated, according to RFC 4566, and moreover there is only one, so it makes a poor default in the case of ST 2022-7 for example. Examples are therefore adjusted:
1. To make the inclusive source-filter used to specify a source-specific multicast (SSM) session as per RFC 4570 different than the Origin unicast address.
2. In the case of any-source multicast in the FEC example, to set the `source_ip` to `null` as per the IS-05 APIs/schemas/receiver_transport_params_rtp.json description. And for clarity, in the any-source multicast example, not to use an IP address in the [IANA-specified SSM block](https://www.iana.org/assignments/multicast-addresses/multicast-addresses.xhtml#multicast-addresses-10)
3. In the case of unicast operation, to set the `source_ip` to `null`. An inclusive source-filter would set the `source_ip`, but without one, I believe the `source_ip` should (or may?) be set to `null` to avoid the issues with the Origin unicast address mentioned already, despite the schema description.