### PR TITLE
Clarify data/type requirements for transport_file and fix examples

### DIFF
--- a/APIs/schemas/receiver-transport-file.json
+++ b/APIs/schemas/receiver-transport-file.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
-  "description": "Transport file parameters. 'data' and 'type' must both be strings or both be null",
+  "description": "Transport file parameters. 'data' and 'type' must both be strings or both be null. If 'type' is non-null 'data' is expected to contain a valid instance of the specified media type.",
   "title": "Transport file",
   "additionalProperties": false,
   "required": [

--- a/examples/receiver-get-200.json
+++ b/examples/receiver-get-200.json
@@ -8,7 +8,7 @@
   },
   "transport_file": {
     "data": null,
-    "type": "application/sdp"
+    "type": null
   },
   "transport_params": [{
     "source_ip": "172.23.19.48",

--- a/examples/receiver-pending-get-200.json
+++ b/examples/receiver-pending-get-200.json
@@ -8,7 +8,7 @@
   },
   "transport_file": {
     "data": null,
-    "type": "application/sdp"
+    "type": null
   },
   "transport_params": [{
     "source_ip": "172.23.19.48",

--- a/examples/receiver-stage-scheduled-absolute.json
+++ b/examples/receiver-stage-scheduled-absolute.json
@@ -8,7 +8,7 @@
   },
   "transport_file": {
     "data": null,
-    "type": "application/sdp"
+    "type": null
   },
   "transport_params": [{
     "interface_ip": "192.168.200.15",

--- a/examples/receiver-stage-scheduled-relative.json
+++ b/examples/receiver-stage-scheduled-relative.json
@@ -8,7 +8,7 @@
   },
   "transport_file": {
     "data": null,
-    "type": "application/sdp"
+    "type": null
   },
   "transport_params": [{
     "interface_ip": "192.168.200.15",

--- a/examples/receiver-stage-success-redundant-streams.json
+++ b/examples/receiver-stage-success-redundant-streams.json
@@ -8,7 +8,7 @@
   },
   "transport_file": {
     "data": null,
-    "type": "application/sdp"
+    "type": null
   },
   "transport_params": [{
     "interface_ip": "192.168.200.15",

--- a/examples/receiver-stage-success.json
+++ b/examples/receiver-stage-success.json
@@ -8,7 +8,7 @@
   },
   "transport_file": {
     "data": null,
-    "type": "application/sdp"
+    "type": null
   },
   "transport_params": [{
     "interface_ip": "192.168.200.15",


### PR DESCRIPTION
Resolves #117 

This attempts to fix the issue highlighted in #117. Some of the existing examples go against the letter of the schema by setting transport_file 'type' to non-null, whilst 'data' is null.