### PR TITLE
Normative language improvements

### DIFF
--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -4,7 +4,7 @@
 # (c) AMWA 2017
 
 title: Connection
-baseUri: http://example.api.com/x-nmos/connection/{version}
+baseUri: http://api.example.com/x-nmos/connection/{version}
 version: v1.1
 mediaType: application/json
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ This document provides an overview of changes between released versions of this 
 
 ## Release v1.1
 *   Add support for MQTT and WebSocket transports
-*   Add a /transporttype resource
+*   Add a `/transporttype` resource
 *   Add support for externally defined transport parameters
-*   Add 409 response code for transports which are unsupported with older API versions
+*   Add `409` (Conflict) response code for transports which are unsupported with older API versions
 
 ## Release v1.0
 *   Initial release

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -7,6 +7,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices' Senders and Receivers.
 
 The Specification includes:
+
 - RAML and JSON Schema definitions, with supporting JSON examples
 - This documentation set, which provides:
   - An overview of the API and how it is used.
@@ -16,7 +17,7 @@ The Specification includes:
 
 IS-05 is intended to be used in conjunction with an [NMOS IS-04 Discovery & Registration](https://specs.amwa.tv/is-04) deployment; however it has been written in such a way to provide useful functionality even in the absence of such a system.
 
-The terms 'Node', 'Device', 'Sender' and 'Receiver' are used extensively in this documenation set. The [NMOS Technical Overview](https://github.com/AMWA-TV/nmos/blob/master/NMOS%20Technical%20Overview.md) provides an outline of these terms, and IS-04 provides 
+The terms 'Node', 'Device', 'Sender' and 'Receiver' are used extensively in this documenation set. The [NMOS Technical Overview](https://specs.amwa.tv/nmos/main/docs/2.0._Technical_Overview.html) provides an outline of these terms, and IS-04 provides corresponding schema definitions.
 
 ## Use of Normative Language
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -1,6 +1,10 @@
 # AMWA IS-05 NMOS Device Connection Management Specification: Overview
+{:.no_toc}
 
-_(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
+
+<!-- _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_  -->
 
 ## Introduction
 
@@ -38,15 +42,15 @@ Restrictions associated with each parameter which is defined for a given transpo
 
 #### Staged
 
-The `staged` endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
+The `/staged` endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
 
 #### Active
 
-The `active` endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of staged settings is activated, these settings transition into the `active` resource.
+The `/active` endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of staged settings is activated, these settings transition into the `/active` resource.
 
 #### Transport File
 
-Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the `transportfile` endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
+Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the `/transportfile` endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
 
 #### Transport Type
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Introduction
 
-AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices` Senders and Receivers.
+AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices' Senders and Receivers.
 
 The Specification includes:
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Introduction
 
-AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices' Senders and Receivers.
+AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices` Senders and Receivers.
 
 The Specification includes:
 
@@ -38,15 +38,15 @@ Restrictions associated with each parameter which is defined for a given transpo
 
 #### Staged
 
-The staged endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
+The `staged` endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
 
 #### Active
 
-The active endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of 'staged' settings is activated, these settings transition into the 'active' resource.
+The `active` endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of staged settings is activated, these settings transition into the `active` resource.
 
 #### Transport File
 
-Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the 'transportfile' endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
+Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the `transportfile` endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
 
 #### Transport Type
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -1,18 +1,27 @@
-# AMWA NMOS Device Connection Management Specification: Overview
+# AMWA IS-05 NMOS Device Connection Management Specification: Overview
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-## Documentation
-
-The documents included in this directory provide additional details and recommendations for implementations of the defined API, and its consumers.
-
 ## Introduction
 
-The purpose of this document is to explain how a Device within an NMOS compatible system can be connected to other Devices via their Senders and Receivers.
+AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices' Senders and Receivers.
 
-The terms 'Node', 'Device', 'Sender' and 'Receiver' will be used extensively throughout this document. Please refer to the core [NMOS Technical Overview](https://github.com/AMWA-TV/nmos/blob/master/NMOS%20Technical%20Overview.md) for definitions of these.
+The Specification includes:
+- RAML and JSON Schema definitions, with supporting JSON examples
+- This documentation set, which provides:
+  - An overview of the API and how it is used.
+  - Normative requirements in addition to those included in the RAML and JSON schemas specifying the API.
+  - Additional details and recommendations for implementers of API providers and clients.
+  - Information about compatibility between different API versions.
 
-This API is intended to be used in conjunction with an [NMOS IS-04 Discovery & Registration](https://github.com/AMWA-TV/nmos-discovery-registration) deployment, however it has been written in such a way to provide useful functionality even in the absence of such a system.
+IS-05 is intended to be used in conjunction with an [NMOS IS-04 Discovery & Registration](https://specs.amwa.tv/is-04) deployment; however it has been written in such a way to provide useful functionality even in the absence of such a system.
+
+The terms 'Node', 'Device', 'Sender' and 'Receiver' are used extensively in this documenation set. The [NMOS Technical Overview](https://github.com/AMWA-TV/nmos/blob/master/NMOS%20Technical%20Overview.md) provides an outline of these terms, and IS-04 provides 
+
+## Use of Normative Language
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY",
+and "OPTIONAL" in this documentation set are to be interpreted as described in [RFC 2119][RFC-2119].
 
 ## API Structure
 
@@ -46,12 +55,12 @@ This endpoint identifies the transport type which is used by this Sender or Rece
 
 The API provides a mechanism to modify settings for an individual Sender or Receiver. This is referred to as the 'single' interface.
 
-The API also provides a mechanism to modify settings for many Senders or Receivers at once which sit within the scope of the API implementation (typically contained by a Node or Device). This is referred to as the 'bulk' interface.
-
-The 'bulk' interface may be used to support specialist 'salvo' operations in capable Devices, as described in [Behaviour](4.0.%20Behaviour.md).
+The API also provides a mechanism to modify settings for many Senders or Receivers at once which sit within the scope of the API implementation (typically contained by a Node or Device). This is referred to as the 'bulk' interface, and can be used to support 'salvo' operations in capable Devices, as described in [Behaviour](4.0.%20Behaviour.md).
 
 ## API Interaction
 
 The following sequence diagram shows the interactions between a client and the API.
 
 ![Connection Management Sequence](images/direct_seq_diagram.png)
+
+[RFC-2119]: https://tools.ietf.org/html/rfc2119 "Key words for use in RFCs"

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -26,7 +26,7 @@ and "OPTIONAL" in this documentation set are to be interpreted as described in [
 
 ## API Structure
 
-The API provides a mechanism to change the settings associated with logical Senders and Receivers which abstract the implementations of different IP based transport protocols. The primary initial use case for this API is in the control of Senders and Receivers which implement the Real Time Protocol (RTP) transport type, but it is extensible to support control of other protocols as required and once defined.
+The API provides a mechanism to change the settings associated with logical Senders and Receivers which abstract the implementations of different IP based transport protocols. The primary initial use case for this API is in the control of Senders and Receivers which implement the Real Time Protocol (RTP) transport type, but it is extensible to support control of other protocols.
 
 ### Resources
 
@@ -38,7 +38,7 @@ Restrictions associated with each parameter which is defined for a given transpo
 
 #### Staged
 
-The staged endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes may be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
+The staged endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
 
 #### Active
 
@@ -46,11 +46,11 @@ The active endpoint reflects the current running configuration of the underlying
 
 #### Transport File
 
-Where a transport protocol is accompanied by file format which advertises connection parameters, this may be exposed via the 'transportfile' endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
+Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the 'transportfile' endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
 
 #### Transport Type
 
-This endpoint identifies the transport type which is used by this Sender or Receiver. It is intended to enable disambiguation between the parameters sets which may be presented under the other resources.
+This endpoint identifies the transport type which is used by this Sender or Receiver. It is intended to enable disambiguation between the parameters sets which can be presented under the other resources.
 
 ### Single & Bulk Interfaces
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -2,11 +2,11 @@
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-This document covers common aspects of the Connection Management API.
+This document covers common aspects of the Connection API.
 
 ## API Specifications
 
-The Connection Management API is specified using:
+The Connection API is specified using:
 
 - The following sub-sections describing common API properties.
 - [RAML](http://raml.org/) documents and [JSON schemas](http://tools.ietf.org/html/draft-zyp-json-schema-04) in the [APIs](../APIs/) folder.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -49,7 +49,6 @@ A v1.1 API response can include:
 
 - v1.1 data without modification.
 - Data conforming to schemas less than v2.0 but greater than v1.1, with any non-v1.1 keys removed.
-- Query API only: Data confirming to schemas less than v1.1 but greater than or equal to v1.0 if a suitable downgrade parameter is specified (see [Query Parameters](2.5.%20APIs%20-%20Query%20Parameters.md)).
 
 ### Common API Base Resource
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -2,19 +2,20 @@
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-This document covers common aspects of Connection Management API. Many of these conventions are matched with the specification of NMOS IS-04. Common conventions may be refactored into a separate repository at a later date.
+This document covers common aspects of the Connection Management API.
 
 ## API Specifications
 
 The Connection Management API is specified using:
-*   The following sub-sections describing common API properties.
-*   [RAML](http://raml.org/) documents and [JSON schemas](http://tools.ietf.org/html/draft-zyp-json-schema-04) in the [APIs](../APIs/) folder.
+
+- The following sub-sections describing common API properties.
+- [RAML](http://raml.org/) documents and [JSON schemas](http://tools.ietf.org/html/draft-zyp-json-schema-04) in the [APIs](../APIs/) folder.
 
 Examples of JSON format output are provided in the [examples](../examples/) folder.
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is strongly recommended that implementers of a Connection Management API use these JSON schemas as part of a validation stage when receiving requests from API clients. Invalid requests should cause a 400 HTTP error (Bad Request) to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a 400 HTTP error (Bad Request) to be returned to the client.
 
 ### Content Types
 
@@ -24,29 +25,35 @@ All APIs MUST provide a JSON representation signalled via 'Content-Type: applica
 
 All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the /x-nmos/ path as follows:
 
-```
+```json
 http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 ```
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
+API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the \'api\' attributes within the Query API /nodes/ path.
+
+Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the 'http' protocol only.
+
 ### Versioning
 
 All public APIs are versioned as follows:
 
-*   Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/connection/) will provide a list containing the versions of the API present on the node.
-*   A versioned API response must include only resources which match the schema for that API version.
-*   Data which is held for mismatched minor API versions may be returned if it can be conformed to the correct schema (see example below). Data must never be conformed between major API versions.
+- Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/query/) will provide a list containing the versions of the API present on the node.
+- A versioned API response MUST include only resources which match the schema for that API version.
+- Data which is held for mismatched minor API versions MAY be returned if it can be conformed to the correct schema (see example below). Data MUST NOT be conformed between major API versions.
 
 **Example**
 
-A v1.1 API response may include:
-*   v1.1 data without modification.
-*   Data conforming to schemas less than v2.0 but greater than v1.1, with any non-v1.1 keys removed.
+A v1.1 API response can include:
+
+- v1.1 data without modification.
+- Data conforming to schemas less than v2.0 but greater than v1.1, with any non-v1.1 keys removed.
+- Query API only: Data confirming to schemas less than v1.1 but greater than or equal to v1.0 if a suitable downgrade parameter is specified (see [Query Parameters](2.5.%20APIs%20-%20Query%20Parameters.md)).
 
 ### Common API Base Resource
 
-```
+```json
 [
   "v1.0/",
   "v2.0/",
@@ -54,12 +61,12 @@ A v1.1 API response may include:
 ]
 ```
 
-*   Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
-*   The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
-*   MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
-*   MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
-*   Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
-*   Clients are responsible for identifying the correct API version they require.
+- Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
+- The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
+- MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
+- MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
+- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+- Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes
 
@@ -69,23 +76,30 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 #### GET and HEAD Requests
 
-* Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
-* When a 301 is supported, the client MUST follow the redirect in order to retrieve the required response payload.
-* Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
+- Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
+- When a 301 is supported, the client MUST follow the redirect in order to retrieve the response payload.
+- Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
 
 #### All Other Requests (PUT, POST, DELETE, OPTIONS etc)
 
-* Clients performing requests using these methods MUST use URLs with no trailing slash present.
-* Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.
-* Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present for backward compatibility.
-* Servers SHOULD NOT respond with 3xx codes for these request types.
+- Clients performing requests using these methods MUST use URLs with no trailing slash present.
+- Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.
+- Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present for backward compatibility.
+- Servers SHOULD NOT respond with 3xx codes for these request types.
+
+#### Client Behaviour
+
+When a server implementation needs to indicate an API URL via an 'href' or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to 'href' type attributes MUST support both cases, avoiding doubled or missing slashes.
 
 ### Error Codes & Responses
 
-The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. As explicit handling of every possible HTTP response code is not expected, clients must instead implement more generic handling for ranges of response codes (1xx, 2xx, 3xx, 4xx and 5xx). For HTTP codes 400 and upwards, a JSON format response MUST be returned as follows:
+The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. Explicit handling of every possible HTTP response code is not expected, but clients are expected to implement generic handling for ranges of response codes (1xx, 2xx, 3xx, 4xx and 5xx).
+
+For HTTP codes 400 and upwards, a JSON format response MUST be returned as follows:
 
 **Example Error Response**
-```
+
+```json
 {
   "code": 400,
   "error": "Human readable message which is suitable for user interface display, and helpful to the user",
@@ -93,6 +107,6 @@ The NMOS APIs use HTTP status codes to indicate success, failure and other cases
 }
 ```
 
-In the above example, the 'code' should always match the HTTP status code. 'error' must always be present and in string format. 'debug' may be null if no further debug information is available.
+In the above example, the 'code' SHOULD match the HTTP status code. 'error' MUST always be present and in string format. 'debug' MAY be null if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -15,7 +15,7 @@ Examples of JSON format output are provided in the [examples](../examples/) fold
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Connection API use these JSON schemas as part of a validation stage when receiving requests from clients. Invalid resources SHOULD cause a `400` (Bad Request) HTTP error to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Connection API use these JSON schemas as part of a validation stage when receiving requests from clients. Invalid requests SHOULD cause a `400` (Bad Request) HTTP error to be returned to the client.
 
 ### Content Types
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -19,7 +19,7 @@ JSON schemas are included with the RAML API definitions. These include validatio
 
 ### Content Types
 
-All APIs MUST provide a JSON representation signalled via 'Content-Type: application/json' headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
+All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
 
 ### API Paths
 
@@ -39,7 +39,7 @@ Where protocol and versioning data is not available, clients MAY assume a v1.0 A
 
 All public APIs are versioned as follows:
 
-- Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/query/) will provide a list containing the versions of the API present on the node.
+- Requesting the API base resource (such as `http(s)://<ip address or hostname>:<port>/x-nmos/query/`) will provide a list containing the versions of the API present on the node.
 - A versioned API response MUST include only resources which match the schema for that API version.
 - Data which is held for mismatched minor API versions MAY be returned if it can be conformed to the correct schema (see example below). Data MUST NOT be conformed between major API versions.
 
@@ -60,11 +60,11 @@ A v1.1 API response can include:
 ]
 ```
 
-- Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
-- The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
+- Appending `/v1.0/` to the API base resource will request version 1.0 of the API if available.
+- The versioning format is `v<#MAJOR>.<#MINOR>`
 - MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
 - MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
-- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
 - Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes
@@ -88,7 +88,7 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 #### Client Behaviour
 
-When a server implementation needs to indicate an API URL via an 'href' or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to 'href' type attributes MUST support both cases, avoiding doubled or missing slashes.
+When a server implementation needs to indicate an API URL via an `href` or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to `href` type attributes MUST support both cases, avoiding doubled or missing slashes.
 
 ### Error Codes & Responses
 
@@ -106,6 +106,6 @@ For HTTP codes 400 and upwards, a JSON format response MUST be returned as follo
 }
 ```
 
-In the above example, the 'code' SHOULD match the HTTP status code. 'error' MUST always be present and in string format. 'debug' MAY be null if no further debug information is available.
+In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be null if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -15,7 +15,7 @@ Examples of JSON format output are provided in the [examples](../examples/) fold
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a `400` (Bad Request) HTTP status to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Connection API use these JSON schemas as part of a validation stage when receiving requests from clients. Invalid resources SHOULD cause a `400` (Bad Request) HTTP error to be returned to the client.
 
 ### Content Types
 
@@ -23,23 +23,19 @@ All APIs MUST provide a JSON representation signalled via `Content-Type: applica
 
 ### API Paths
 
-All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the /x-nmos/ path as follows:
+All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the `/x-nmos/` path as follows:
 
-```json
+```
 http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 ```
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
-API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the \'api\' attributes within the Query API /nodes/ path.
-
-Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the 'http' protocol only.
-
 ### Versioning
 
 All public APIs are versioned as follows:
 
-- Requesting the API base resource (such as `http(s)://<ip address or hostname>:<port>/x-nmos/query/`) will provide a list containing the versions of the API present on the node.
+- Requesting the API base resource (such as `http(s)://<ip address or hostname>:<port>/x-nmos/connection/`) will provide a list containing the versions of the API present on the node.
 - A versioned API response MUST include only resources which match the schema for that API version.
 - Data which is held for mismatched minor API versions MAY be returned if it can be conformed to the correct schema (see example below). Data MUST NOT be conformed between major API versions.
 
@@ -60,11 +56,11 @@ A v1.1 API response can include:
 ]
 ```
 
-- Appending `/v1.0/` to the API base resource will request version 1.0 of the API if available.
-- The versioning format is `v<#MAJOR>.<#MINOR>`
-- MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
-- MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
-- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+- Appending `/v1.0/` to the API base resource will request the version v1.0 of the API if available.
+- The versioning format is `v<MAJOR>.<MINOR>`
+- `MINOR` increments will be performed for non-breaking changes (such as the addition of attributes in a response)
+- `MAJOR` increments will be performed for breaking changes (such as the renaming of a resource or attribute)
+- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of `MAJOR`, `MINOR` version (such that v1.12 is greater than v1.5).
 - Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes
@@ -106,6 +102,6 @@ For HTTP codes `400` and upwards, a JSON format response MUST be returned as fol
 }
 ```
 
-In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
+`code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -19,7 +19,7 @@ JSON schemas are included with the RAML API definitions. These include validatio
 
 ### Content Types
 
-All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
+All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via `Accept` headers.
 
 ### API Paths
 
@@ -106,6 +106,6 @@ For HTTP codes `400` and upwards, a JSON format response MUST be returned as fol
 }
 ```
 
-In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be null if no further debug information is available.
+In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -15,7 +15,7 @@ Examples of JSON format output are provided in the [examples](../examples/) fold
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a 400 HTTP error (Bad Request) to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a `400` (Bad Request) HTTP status to be returned to the client.
 
 ### Content Types
 
@@ -75,16 +75,16 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 #### `GET` and `HEAD` Requests
 
-- Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
-- When a 301 is supported, the client MUST follow the redirect in order to retrieve the response payload.
-- Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
+- Clients performing requests using these methods SHOULD correctly handle a `301` (Moved Permanently) response.
+- When a `301` is supported, the client MUST follow the redirect in order to retrieve the response payload.
+- Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a `301` response causing a redirect to the other if preferred.
 
 #### All Other Requests (`PUT`, `POST`, `DELETE`, `OPTIONS`, etc.)
 
 - Clients performing requests using these methods MUST use URLs with no trailing slash present.
 - Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.
 - Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present for backward compatibility.
-- Servers SHOULD NOT respond with 3xx codes for these request types.
+- Servers SHOULD NOT respond with `3xx` codes for these request types.
 
 #### Client Behaviour
 
@@ -92,9 +92,9 @@ When a server implementation needs to indicate an API URL via an `href` or simil
 
 ### Error Codes & Responses
 
-The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. Explicit handling of every possible HTTP response code is not expected, but clients are expected to implement generic handling for ranges of response codes (1xx, 2xx, 3xx, 4xx and 5xx).
+The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. Explicit handling of every possible HTTP response code is not expected, but clients are expected to implement generic handling for ranges of response codes (`1xx`, `2xx`, `3xx`, `4xx` and `5xx`).
 
-For HTTP codes 400 and upwards, a JSON format response MUST be returned as follows:
+For HTTP codes `400` and upwards, a JSON format response MUST be returned as follows:
 
 **Example Error Response**
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -73,13 +73,13 @@ For consistency and in order to adhere to how these APIs are specified in RAML, 
 
 In order to overcome shortcomings in some common libraries, the following requirements are imposed for the support of URL paths with or without trailing slashes.
 
-#### GET and HEAD Requests
+#### `GET` and `HEAD` Requests
 
 - Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
 - When a 301 is supported, the client MUST follow the redirect in order to retrieve the response payload.
 - Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
 
-#### All Other Requests (PUT, POST, DELETE, OPTIONS etc)
+#### All Other Requests (`PUT`, `POST`, `DELETE`, `OPTIONS`, etc.)
 
 - Clients performing requests using these methods MUST use URLs with no trailing slash present.
 - Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -4,19 +4,16 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Conforming to Schemas
 
-When interacting with a Connection Management API, a client may assume the presence of a core set of attributes for each defined transport type. Other parameters may be defined by the specification, but are optional for implementations given that they may or may not implement a particular feature. Presence of these attributes in an implementation cannot be assumed and must be identified via the '/constraints' resource of a running Device. A list of core attributes, and attributes associated with particular features, is given in [Behaviour - RTP Transport Type](4.1.%20Behaviour%20-%20RTP%20Transport%20Type.md) and further pages in the [Behaviour](4.0.%20Behaviour.md) section.
-
-For core attributes, individual APIs may still constrain their permitted values to a particular range or enumeration, so parsing the constraints is still recommended.
-
+The Connection Management API schemas define sets of parameters for each supported transport type; these are also described in pages in the [Behaviour](4.0.%20Behaviour.md) section of these documents. The schemas define which parameters are always present (core), and which are feature-dependent; a client can determine what a Device supports by getting its `/constraints` resource, and SHOULD parse this resource in all cases as a Device might have a constrained range or enumeration of supported values, even for core paramters.
 
 ## RTP Operating Point
 
-When establishing an RTP connection between two Devices that implement NMOS Connection Management, the expectation is that the primary means of connection will be to supply the SDP file from the Sender to the Receiver. This ensures Receivers have the media information in the SDP file. If desired the client may adjust individual transport parameters on the Receiver. For example it may use the `rtcp_enable` parameter to toggle RTCP operation.
+When establishing an RTP connection between two Devices that implement NMOS Connection Management, the expectation is that the primary means of connection will be to supply the SDP file from the Sender to the Receiver. This ensures Receivers have the media information in the SDP file. If desired the client can adjust individual transport parameters on the Receiver. For example it could use the `rtcp_enable` parameter to toggle RTCP operation.
 
-When receiving from a (non-NMOS) Device which does not provide an SDP file, a connection may be established using transport parameters alone. In this case it may be necessary to provide media information out-of-band.
+When receiving from a (non-NMOS) Device which does not provide an SDP file, a connection can be established using transport parameters alone. In this case it might be necessary to provide media information out-of-band.
 
 ## Failure Modes
 
-If a client receives an HTTP 500 response code from the API a failure has occurred. The client should display the content of the response's `error` field to the user if possible, and indicate that the Device may be in a bad state. The client should also refresh the values in the `/staged` and `/active` endpoints to ensure it is accurately reflecting the current state of the API.
+If a client receives an HTTP 500 response code from the API a failure has occurred and the `error` field can be used to indicate to a user that the Device might be in a bad state. In such a case the client SHOULD refresh the values in the `/staged` and `/active` endpoints to reflect the current state of the API.
 
 If an activation is triggered across multiple Senders and Receivers using the `/bulk` interface, Senders and Receivers will transition to their new active parameters, even if some Senders or Receivers in the same salvo fail to activate. It is the responsibility of the client to recover from this situation if desired, including reverting Senders and Receivers that have successfully activated back to their original state where necessary.

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Conforming to Schemas
 
-The Connection API schemas define sets of parameters for each supported transport type; these are also described in pages in the [Behaviour](4.0.%20Behaviour.md) section of these documents. The schemas define which parameters are always present (core), and which are feature-dependent; a client can determine what a Device supports by getting its `/constraints` resource, and SHOULD parse this resource in all cases as a Device might have a constrained range or enumeration of supported values, even for core paramters.
+The Connection API schemas define sets of parameters for each supported transport type; these are also described in pages in the [Behaviour](4.0.%20Behaviour.md) section of these documents. These pages define which parameters are always present (core), and which are feature-dependent; a client can determine what a Device supports by getting its `/constraints` resource, and SHOULD parse this resource in all cases as a Device might have a constrained range or enumeration of supported values, even for core parameters.
 
 ## RTP Operating Point
 

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Conforming to Schemas
 
-The Connection Management API schemas define sets of parameters for each supported transport type; these are also described in pages in the [Behaviour](4.0.%20Behaviour.md) section of these documents. The schemas define which parameters are always present (core), and which are feature-dependent; a client can determine what a Device supports by getting its `/constraints` resource, and SHOULD parse this resource in all cases as a Device might have a constrained range or enumeration of supported values, even for core paramters.
+The Connection API schemas define sets of parameters for each supported transport type; these are also described in pages in the [Behaviour](4.0.%20Behaviour.md) section of these documents. The schemas define which parameters are always present (core), and which are feature-dependent; a client can determine what a Device supports by getting its `/constraints` resource, and SHOULD parse this resource in all cases as a Device might have a constrained range or enumeration of supported values, even for core paramters.
 
 ## RTP Operating Point
 

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -14,6 +14,6 @@ When receiving from a (non-NMOS) Device which does not provide an SDP file, a co
 
 ## Failure Modes
 
-If a client receives an HTTP 500 response code from the API a failure has occurred and the `error` field can be used to indicate to a user that the Device might be in a bad state. In such a case the client SHOULD refresh the values in the `/staged` and `/active` endpoints to reflect the current state of the API.
+If a client receives an HTTP `500` (Internal Server Error) response code from the API a failure has occurred and the `error` field can be used to indicate to a user that the Device might be in a bad state. In such a case the client SHOULD refresh the values in the `/staged` and `/active` endpoints to reflect the current state of the API.
 
 If an activation is triggered across multiple Senders and Receivers using the `/bulk` interface, Senders and Receivers will transition to their new active parameters, even if some Senders or Receivers in the same salvo fail to activate. It is the responsibility of the client to recover from this situation if desired, including reverting Senders and Receivers that have successfully activated back to their original state where necessary.

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -8,9 +8,9 @@ In order to permit web-based control interfaces to be hosted remotely, all NMOS 
 
 In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight OPTIONS requests. Servers MAY additionally support HTTP OPTIONS requests made to any other API resource.
 
-In order to simplify development, the following headers may be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and may not be suitable for a production deployment.
+In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and might not be suitable for a production deployment.
 
-```
+```http
 Access-Control-Allow-Origin: *
 Access-Control-Allow-Methods: GET, PUT, POST, PATCH, HEAD, OPTIONS, DELETE
 Access-Control-Allow-Headers: Content-Type, Accept
@@ -21,34 +21,35 @@ To ensure compatibility, the response 'Access-Control-Allow-Headers' could be se
 
 ## Use of '.local' Hostnames
 
-Where 'href' or 'host' attributes are specified in the APIs, it is strongly recommended to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst '.local' hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames may result in Nodes appearing inaccessible.
+Where 'href' or 'host' attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst '.local' hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
 
 ## Un-initialised Senders and Receivers
 
-When a Sender or Receiver is first started it may not have all the parameters it needs to operate. For example IP addresses and port numbers may not be set. In this instance:
+When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
-*   Senders and Receivers should present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Parameters such as port numbers may have defaults in various RFCs that should be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, should be set to null.
-*   Senders that are not configured (for example have a null source IP address value), should return 404 on their active transport file endpoint, until a usable set of parameters has been activated.
+- Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to null.
+- Senders that are not configured (for example have a null source IP address value) SHOULD return 404 on their active transport file endpoint, until a usable set of parameters has been activated.
 
-However Senders and Receivers may start with parameters already configured, for example through use of a configuration file or manual entry of parameters.
+(In other cases, Senders and Receivers might start with parameters already configured, for example through use of a configuration file or manual entry of parameters.)
 
 ## Use of auto
-Many transport parameters in the API may be set to "auto" in the `/staged` endpoint, to imply the Sender or Receiver should select that parameter for itself. In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas. For example a port number may be offset from the RTP port number by a pre-determined value. The specification makes suggestions of a sensible default value for "auto" to resolve to, but the Sender or Receiver may choose any value permitted by the schema and constraints.
 
-Transport parameters which are required to support "auto" are defined in the specification. It is not recommended for implementations to indicate "auto" as an option via their `/constraints` endpoint.
+Many transport parameters MAY be set to "auto" in the `/staged` endpoint, to tell the Sender or Receiver to select the parameter for itself. In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas. For example a port number might be offset from the RTP port number by a pre-determined value. The specification makes suggestions of a sensible default value for "auto" to resolve to, but the Sender or Receiver might choose any value permitted by the schema and constraints.
 
-In some cases the behaviour is more complex, and may be determined by the vendor. These cases are indicated in section 4 against the specific transport types.
+Transport parameters which need to support "auto" are defined in the specification. Implementations SHOULD NOT indicate "auto" as an option via their `/constraints` endpoint.
+
+In some cases the behaviour is more complex, and can be determined by the vendor. These cases are indicated in section 4 for the specific transport types.
 
 ## Constraints
 
 ### Use of JSON Schema with Constraints
 
-It is strongly recommended that API implementations validate requests received from clients against the JSON schema included in this specification. Where additional constraints are applied by the API using the '/constraints' resource, these restrictions should be merged with the provided JSON schema in order to provide consistent validation.
+It is STRONGLY RECOMMENDED that API implementations validate requests received from clients against the JSON schema included in this specification. Where additional constraints are applied by the API using the `/constraints` resource, these restrictions SHOULD be merged with the provided JSON schema in order to provide consistent validation.
 
 ### Constraining Interfaces
 
-The constraints are used to advertise the available network interfaces on the Device. This may be done through use of an `enum` constraint, which contains an array of the available interface IP addresses. For interfaces capable of operating with IPv6 and IPv4 each interface should have two entries containing the interface's IPv4 and IPv6 addresses. Examples are provided in the API documentation.
+The constraints are used to advertise the available network interfaces on the Device. This happens through use of an `enum` constraint, which contains an array of the available interface IP addresses. For interfaces capable of operating with IPv6 and IPv4 each interface SHOULD have two entries containing the interface's IPv4 and IPv6 addresses. Examples are provided in the API documentation.
 
 ## Staged Requests Precedence
 
-It is possible to make a `PATCH` request to the `/staged` Receiver endpoint containing both a transport file and transport parameters. Where the content of the transport file and the transport parameters are not in agreement, the transport parameters take precedence. For example, if a transport file specifies a multicast group address of `232.19.133.29` but the transport parameter `multicast_ip` specified a multicast group of `232.20.44.7` then the Receiver should use `232.20.44.7`.
+It is possible to make a `PATCH` request to the `/staged` Receiver endpoint containing both a transport file and transport parameters. Where the content of the transport file and the transport parameters are not in agreement, the transport parameters take precedence. For example, if a transport file specifies a multicast group address of `232.19.133.29` but the transport parameter `multicast_ip` specified a multicast group of `232.20.44.7` then the Receiver will use `232.20.44.7`.

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -8,7 +8,7 @@ In order to permit web-based control interfaces to be hosted remotely, all NMOS 
 
 In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP `OPTIONS` requests made to any other API resource.
 
-In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and might not be suitable for a production deployment.
+In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and possibly not suitable for a production deployment.
 
 ```http
 Access-Control-Allow-Origin: *
@@ -21,9 +21,9 @@ To ensure compatibility, the response `Access-Control-Allow-Headers` could be se
 
 ## Use of `.local` Hostnames
 
-Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
+Where `href` or `host` attributes are specified in the APIs, it is strongly RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames can result in Nodes appearing inaccessible.
 
-## Un-initialised Senders and Receivers
+## Uninitialised Senders and Receivers
 
 When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
@@ -44,7 +44,7 @@ In some cases the behaviour is more complex, and can be determined by the vendor
 
 ### Use of JSON Schema with Constraints
 
-It is STRONGLY RECOMMENDED that API implementations validate requests received from clients against the JSON schema included in this specification. Where additional constraints are applied by the API using the `/constraints` resource, these restrictions SHOULD be merged with the provided JSON schema in order to provide consistent validation.
+It is strongly RECOMMENDED that API implementations validate requests received from clients against the JSON schema included in this specification. Where additional constraints are applied by the API using the `/constraints` resource, these restrictions SHOULD be merged with the provided JSON schema in order to provide consistent validation.
 
 ### Constraining Interfaces
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -34,9 +34,9 @@ When a Sender or Receiver is first started it might not have all the parameters 
 
 ## Use of auto
 
-Many transport parameters MAY be set to "auto" in the `/staged` endpoint, to tell the Sender or Receiver to select the parameter for itself. In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas. For example a port number might be offset from the RTP port number by a pre-determined value. The specification makes suggestions of a sensible default value for "auto" to resolve to, but the Sender or Receiver might choose any value permitted by the schema and constraints.
+Many transport parameters MAY be set to `"auto"` in the `/staged` endpoint, to tell the Sender or Receiver to select the parameter for itself. In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas. For example a port number might be offset from the RTP port number by a pre-determined value. The specification makes suggestions of a sensible default value for `"auto"` to resolve to, but the Sender or Receiver might choose any value permitted by the schema and constraints.
 
-Transport parameters which need to support "auto" are defined in the specification. Implementations SHOULD NOT indicate "auto" as an option via their `/constraints` endpoint.
+Transport parameters which need to support `"auto"` are defined in the specification. Implementations SHOULD NOT indicate `"auto"` as an option via their `/constraints` endpoint.
 
 In some cases the behaviour is more complex, and can be determined by the vendor. These cases are indicated in section 4 for the specific transport types.
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -27,8 +27,8 @@ Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECO
 
 When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
-- Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to null.
-- Senders that are not configured (for example have a null source IP address value) SHOULD return `404` (Not Found) on their active transport file endpoint, until a usable set of parameters has been activated.
+- Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to `null`.
+- Senders that are not configured (for example have a `null` source IP address value) SHOULD return `404` (Not Found) on their active transport file endpoint, until a usable set of parameters has been activated.
 
 (In other cases, Senders and Receivers might start with parameters already configured, for example through use of a configuration file or manual entry of parameters.)
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -28,7 +28,7 @@ Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECO
 When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
 - Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to null.
-- Senders that are not configured (for example have a null source IP address value) SHOULD return 404 on their active transport file endpoint, until a usable set of parameters has been activated.
+- Senders that are not configured (for example have a null source IP address value) SHOULD return `404` (Not Found) on their active transport file endpoint, until a usable set of parameters has been activated.
 
 (In other cases, Senders and Receivers might start with parameters already configured, for example through use of a configuration file or manual entry of parameters.)
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -6,7 +6,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 In order to permit web-based control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses to all requests.
 
-In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight OPTIONS requests. Servers MAY additionally support HTTP OPTIONS requests made to any other API resource.
+In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP `OPTIONS` requests made to any other API resource.
 
 In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and might not be suitable for a production deployment.
 
@@ -17,11 +17,11 @@ Access-Control-Allow-Headers: Content-Type, Accept
 Access-Control-Max-Age: 3600
 ```
 
-To ensure compatibility, the response 'Access-Control-Allow-Headers' could be set from the request's 'Access-Control-Request-Headers'.
+To ensure compatibility, the response `Access-Control-Allow-Headers` could be set from the request's `Access-Control-Request-Headers`.
 
-## Use of '.local' Hostnames
+## Use of `.local` Hostnames
 
-Where 'href' or 'host' attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst '.local' hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
+Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
 
 ## Un-initialised Senders and Receivers
 

--- a/docs/3.0. Interoperability.md
+++ b/docs/3.0. Interoperability.md
@@ -2,4 +2,4 @@
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-The Connection Management API is intended to be used alongside other NMOS specifications, and may also be used alongside other common non-NMOS specifications. These documents cover common interoperability requirements when operating in either of these situations.
+The Connection Management API is intended to be used alongside other NMOS specifications, and can also be used alongside other common non-NMOS specifications. These documents cover common interoperability requirements when operating in either of these situations.

--- a/docs/3.0. Interoperability.md
+++ b/docs/3.0. Interoperability.md
@@ -2,4 +2,4 @@
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-The Connection Management API is intended to be used alongside other NMOS specifications, and can also be used alongside other common non-NMOS specifications. These documents cover common interoperability requirements when operating in either of these situations.
+The Connection API is intended to be used alongside other NMOS specifications, and can also be used alongside other common non-NMOS specifications. These documents cover common interoperability requirements when operating in either of these situations.

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -8,7 +8,7 @@ When this API is used alongside IS-04 in a deployment, the IS-04 APIs SHOULD be 
 
 ## Discovery
 
-The Connection Management API SHOULD be advertised as a `control` endpoint when publishing a compliant NMOS Device.
+The Connection Management API SHOULD be advertised as a control endpoint when publishing a compliant NMOS Device.
 Control interfaces can identify all Devices which implement the Connection Management API by a `type` Uniform Resource Name (URN) having the base `urn:x-nmos:control:sr-ctrl` followed by a `/` character and the API version.
 The associated `href` is the URL of the Connection API base resource.
 
@@ -29,7 +29,7 @@ As shown above the API version is included in the `type`, and in the `href`. Fur
 
 More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate `control` endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
+A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate endpoint for each Device's Connection Management instance MUST be advertised in the Device's `controls`, even if the URI is the same.
 
 API implementations MAY list an `href` with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto `href`s.
 
@@ -43,7 +43,7 @@ In order to prevent unnecessary polling of the Connection Management API, change
 
 ## Identifying Active Connections
 
-In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using null) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
+In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using `null`) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
 
 ## Support For Legacy IS-04 Connection Management
 

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -47,7 +47,7 @@ In order to populate the `subscription` attribute of IS-04 Senders and Receivers
 
 ## Support For Legacy IS-04 Connection Management
 
-The Connection Management API supersedes the now deprecated method of updating the `target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
+The Connection Management API supersedes the now deprecated method of updating the `/target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
 
 - Where a client updates the Node API subscription, the result on the Connection Management API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
 - Where a client updates a Connection Management API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -8,11 +8,11 @@ When this API is used alongside IS-04 in a deployment, the IS-04 APIs SHOULD be 
 
 ## Discovery
 
-The Connection Management API SHOULD be advertised as a 'control' endpoint when publishing a compliant NMOS Device.
-Control interfaces can identify all Devices which implement the Connection Management API by a 'type' Uniform Resource Name (URN) having the base 'urn:x-nmos:control:sr-ctrl' followed by a '/' character and the API version.
-The associated 'href' is the URL of the Connection API base resource.
+The Connection Management API SHOULD be advertised as a `control` endpoint when publishing a compliant NMOS Device.
+Control interfaces can identify all Devices which implement the Connection Management API by a `type` Uniform Resource Name (URN) having the base `urn:x-nmos:control:sr-ctrl` followed by a `/` character and the API version.
+The associated `href` is the URL of the Connection API base resource.
 
-**Example:** The 'controls' attribute of a single NMOS Device
+**Example:** The `controls` attribute of a single NMOS Device
 
 ```json
 ...
@@ -25,13 +25,13 @@ The associated 'href' is the URL of the Connection API base resource.
 ...
 ```
 
-As shown above the API version is included in the 'type', and in the 'href'. Further control endpoints for the Connection Management API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
+As shown above the API version is included in the `type`, and in the `href`. Further control endpoints for the Connection Management API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
 
 More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate 'control' endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
+A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate `control` endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
 
-API implementations MAY list an 'href' with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto 'hrefs'.
+API implementations MAY list an `href` with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto `href`s.
 
 ## Sender & Receiver IDs
 
@@ -39,7 +39,7 @@ The UUIDs used to advertise Senders and Receivers in the Connection Management A
 
 ## Version Increments
 
-In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the 'active' parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
+In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the `active` parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
 
 ## Identifying Active Connections
 
@@ -47,7 +47,7 @@ In order to populate the `subscription` attribute of IS-04 Senders and Receivers
 
 ## Support For Legacy IS-04 Connection Management
 
-The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
+The Connection Management API supersedes the now deprecated method of updating the `target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
 
 - Where a client updates the Node API subscription, the result on the Connection Management API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
 - Where a client updates a Connection Management API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -4,16 +4,17 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 The Connection Management API shares a data model with the NMOS IS-04 specification, and as a result it is designed to be used alongside it. The following implementation notes identify correct behaviour for doing this.
 
-When this API is used alongside IS-04 in a deployment, the IS-04 APIs should be operating at version 1.2 or greater in order to ensure full interoperability.
+When this API is used alongside IS-04 in a deployment, the IS-04 APIs SHOULD be operating at version 1.2 or greater in order to ensure full interoperability.
 
 ## Discovery
 
-The Connection Management API should be advertised as a 'control' endpoint when publishing a compliant NMOS Device.
+The Connection Management API SHOULD be advertised as a 'control' endpoint when publishing a compliant NMOS Device.
 Control interfaces can identify all Devices which implement the Connection Management API by a 'type' Uniform Resource Name (URN) having the base 'urn:x-nmos:control:sr-ctrl' followed by a '/' character and the API version.
 The associated 'href' is the URL of the Connection API base resource.
 
 **Example:** The 'controls' attribute of a single NMOS Device
-```
+
+```json
 ...
 "controls": [
   {
@@ -24,32 +25,32 @@ The associated 'href' is the URL of the Connection API base resource.
 ...
 ```
 
-Note as above that the API version is included in the 'type', and in the 'href'. Further control endpoints for the Connection Management API may be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
+As shown above the API version is included in the 'type', and in the 'href'. Further control endpoints for the Connection Management API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
 
 More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API may offer control of multiple Devices in a Node from a single URI. Alternatively there may be multiple instances of the API on one Node, each corresponding to one Device. A separate 'control' endpoint for each Device's Connection Management instance must be advertised, even if the URI is the same.
+A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate 'control' endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
 
-API implementations may list an 'href' with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. In order to avoid cases of double slashes or missing slashes, clients are required to exercise caution when appending paths onto this 'href'.
+API implementations MAY list an 'href' with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto 'hrefs'.
 
 ## Sender & Receiver IDs
 
-The UUIDs used to advertise Senders and Receivers in the Connection Management API must match those used in a corresponding IS-04 implementation.
+The UUIDs used to advertise Senders and Receivers in the Connection Management API MUST match those used in a corresponding IS-04 implementation.
 
 ## Version Increments
 
-In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters should be signalled via the IS-04 versioning mechanism. When the 'active' parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver must be incremented.
+In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the 'active' parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
 
 ## Identifying Active Connections
 
-In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These should be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using null) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
+In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using null) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
 
 ## Support For Legacy IS-04 Connection Management
 
-The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice should be followed when both are in use:
+The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
 
-*   Where a client updates the Node API subscription, the result on the Connection Management API should be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
-*   Where a client updates a Connection Management API Receiver the active `sender_id` parameter should be populated in the Node API subscription parameter with key `sender_id`.
-*   After a Connection Management API activation the corresponding Sender or Receiver's `version` property should be updated to the instant of the activation.
+- Where a client updates the Node API subscription, the result on the Connection Management API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
+- Where a client updates a Connection Management API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.
+- After a Connection Management API activation the corresponding Sender or Receiver's `version` property SHOULD be updated to the instant of the activation.
 
 If staged modifications are present when a legacy activation is performed, these parameters MUST be discarded in favour of those provided via the Node API interface.

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -52,4 +52,4 @@ The Connection Management API supersedes the now deprecated method of updating t
 *   Where a client updates a Connection Management API Receiver the active `sender_id` parameter should be populated in the Node API subscription parameter with key `sender_id`.
 *   After a Connection Management API activation the corresponding Sender or Receiver's `version` property should be updated to the instant of the activation.
 
-Should staged modifications be present when a legacy activation is performed, these parameters must be discarded in favour of those provided via the Node API interface.
+If staged modifications are present when a legacy activation is performed, these parameters MUST be discarded in favour of those provided via the Node API interface.

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -2,14 +2,14 @@
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-The Connection Management API shares a data model with the NMOS IS-04 specification, and as a result it is designed to be used alongside it. The following implementation notes identify correct behaviour for doing this.
+The Connection API shares a data model with the NMOS IS-04 specification, and as a result it is designed to be used alongside it. The following implementation notes identify correct behaviour for doing this.
 
 When this API is used alongside IS-04 in a deployment, the IS-04 APIs SHOULD be operating at version 1.2 or greater in order to ensure full interoperability.
 
 ## Discovery
 
-The Connection Management API SHOULD be advertised as a control endpoint when publishing a compliant NMOS Device.
-Control interfaces can identify all Devices which implement the Connection Management API by a `type` Uniform Resource Name (URN) having the base `urn:x-nmos:control:sr-ctrl` followed by a `/` character and the API version.
+The Connection API SHOULD be advertised as a control endpoint when publishing a compliant NMOS Device.
+Control interfaces can identify all Devices which implement the Connection API by a `type` Uniform Resource Name (URN) having the base `urn:x-nmos:control:sr-ctrl` followed by a `/` character and the API version.
 The associated `href` is the URL of the Connection API base resource.
 
 **Example:** The `controls` attribute of a single NMOS Device
@@ -25,32 +25,32 @@ The associated `href` is the URL of the Connection API base resource.
 ...
 ```
 
-As shown above the API version is included in the `type`, and in the `href`. Further control endpoints for the Connection Management API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
+As shown above the API version is included in the `type`, and in the `href`. Further control endpoints for the Connection API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
 
 More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate endpoint for each Device's Connection Management instance MUST be advertised in the Device's `controls`, even if the URI is the same.
+A given instance of the Connection API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate endpoint for each Device's Connection Management instance MUST be advertised in the Device's `controls`, even if the URI is the same.
 
 API implementations MAY list an `href` with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto `href`s.
 
 ## Sender & Receiver IDs
 
-The UUIDs used to advertise Senders and Receivers in the Connection Management API MUST match those used in a corresponding IS-04 implementation.
+The UUIDs used to advertise Senders and Receivers in the Connection API MUST match those used in a corresponding IS-04 implementation.
 
 ## Version Increments
 
-In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the `active` parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
+In order to prevent unnecessary polling of the Connection API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the `active` parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
 
 ## Identifying Active Connections
 
-In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using `null`) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
+In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using `null`) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
 
 ## Support For Legacy IS-04 Connection Management
 
-The Connection Management API supersedes the now deprecated method of updating the `/target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
+The Connection API supersedes the now deprecated method of updating the `/target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
 
-- Where a client updates the Node API subscription, the result on the Connection Management API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
-- Where a client updates a Connection Management API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.
-- After a Connection Management API activation the corresponding Sender or Receiver's `version` property SHOULD be updated to the instant of the activation.
+- Where a client updates the Node API subscription, the result on the Connection API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
+- Where a client updates a Connection API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.
+- After a Connection API activation the corresponding Sender or Receiver's `version` property SHOULD be updated to the instant of the activation.
 
 If staged modifications are present when a legacy activation is performed, these parameters MUST be discarded in favour of those provided via the Node API interface.

--- a/docs/3.2. Interoperability - Non-NMOS Devices.md
+++ b/docs/3.2. Interoperability - Non-NMOS Devices.md
@@ -4,6 +4,6 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Interacting with Non-NMOS Devices
 
-In practical deployments it is expected that some Devices will exist which do not support the NMOS specifications, but which do support matching transport protocols. When connecting to one of these Devices via the Connection Management API, the `sender_id` and `receiver_id` parameters should be set to null by the client.
+In practical deployments it is expected that some Devices will exist which do not support the NMOS specifications, but which do support matching transport protocols. When connecting to one of these Devices via the Connection Management API, the `sender_id` and `receiver_id` parameters SHOULD be set to null by the client.
 
-In cases where another connection management protocol is used to achieve this (for example RTSP in the case of the RTP transport), the Connection Management API must still be updated to reflect the running parameters which have been set via this alternative protocol.
+In cases where another connection management protocol is used to achieve this (for example RTSP in the case of the RTP transport), the Connection Management API MUST still be updated to reflect the running parameters which have been set via this alternative protocol.

--- a/docs/3.2. Interoperability - Non-NMOS Devices.md
+++ b/docs/3.2. Interoperability - Non-NMOS Devices.md
@@ -4,6 +4,6 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Interacting with Non-NMOS Devices
 
-In practical deployments it is expected that some Devices will exist which do not support the NMOS specifications, but which do support matching transport protocols. When connecting to one of these Devices via the Connection Management API, the `sender_id` and `receiver_id` parameters SHOULD be set to null by the client.
+In practical deployments it is expected that some Devices will exist which do not support the NMOS specifications, but which do support matching transport protocols. When connecting to one of these Devices via the Connection API, the `sender_id` and `receiver_id` parameters SHOULD be set to null by the client.
 
-In cases where another connection management protocol is used to achieve this (for example RTSP in the case of the RTP transport), the Connection Management API MUST still be updated to reflect the running parameters which have been set via this alternative protocol.
+In cases where another connection management protocol is used to achieve this (for example RTSP in the case of the RTP transport), the Connection API MUST still be updated to reflect the running parameters which have been set via this alternative protocol.

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -18,7 +18,7 @@ This is important to ensure that connection management clients do not cache the 
 
 ## Multi-Client Operation
 
-In environments where multiple clients might be operating against a single Connection Management API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP `PATCH` operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
+In environments where multiple clients might be operating against a single Connection API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP `PATCH` operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
 
 ## In-Progress Activations
 
@@ -29,7 +29,7 @@ When an implementation is in the process of activating a new set of transport pa
 
 ## Connection Status
 
-The Connection Management API does not take any responsibility for monitoring the status of a connection between a Sender and a Receiver, for example whether a Receiver is currently receiving packets. As such a loss of packets at a connectionless Receiver (e.g. UDP) or a recoverable error on a connection-oriented transport (e.g. TCP) MUST NOT be indicated via changes to the `/active` resource. Where a connection-oriented transport encounters a recoverable error (such as a broken connection or timeout), the underlying Sender or Receiver SHOULD attempt to recover from the error unless otherwise configured not to do so. This could involve the use of exponential backoff up to a defined limit. Where a Sender or Receiver is permanently unable to recover a connection-oriented transport without user interaction, for example due to erroneous configuration which was not identified prior to activation, the implementation MAY set `master_enable` to `false` in the `/active` resource.
+The Connection API does not take any responsibility for monitoring the status of a connection between a Sender and a Receiver, for example whether a Receiver is currently receiving packets. As such a loss of packets at a connectionless Receiver (e.g. UDP) or a recoverable error on a connection-oriented transport (e.g. TCP) MUST NOT be indicated via changes to the `/active` resource. Where a connection-oriented transport encounters a recoverable error (such as a broken connection or timeout), the underlying Sender or Receiver SHOULD attempt to recover from the error unless otherwise configured not to do so. This could involve the use of exponential backoff up to a defined limit. Where a Sender or Receiver is permanently unable to recover a connection-oriented transport without user interaction, for example due to erroneous configuration which was not identified prior to activation, the implementation MAY set `master_enable` to `false` in the `/active` resource.
 
 ## 'Salvo' Operation
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -8,7 +8,7 @@ If an explicit activation is performed against a Sender or Receiver, the API MUS
 
 ## Transport Files & Caching
 
-It is STRONGLY RECOMMENDED that the following caching headers are included via the /transportfile endpoint (or whatever this endpoint redirects to).
+It is STRONGLY RECOMMENDED that the following caching headers are included via the `/transportfile` endpoint (or whatever this endpoint redirects to).
 
 ```http
 Cache-Control: no-cache
@@ -18,14 +18,14 @@ This is important to ensure that connection management clients do not cache the 
 
 ## Multi-Client Operation
 
-In environments where multiple clients might be operating against a single Connection Management API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP PATCH operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
+In environments where multiple clients might be operating against a single Connection Management API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP `PATCH` operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
 
 ## In-Progress Activations
 
 When an implementation is in the process of activating a new set of transport parameters, concurrent requests to the API from other clients could result in unexpected results. In order to minimise these cases, implementations are RECOMMENDED to adopt the following practice:
 
-- While an activation is in progress, concurrent GET requests to the `/active` resource SHOULD reflect the current configuration of the Sender or Receiver as accurately as possible at the instant of the request.
-- If an API implementation receives a new PATCH request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any GET requests to `/staged` during this time MAY also be blocked until the activation is complete.
+- While an activation is in progress, concurrent `GET` requests to the `/active` resource SHOULD reflect the current configuration of the Sender or Receiver as accurately as possible at the instant of the request.
+- If an API implementation receives a new `PATCH` request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any `GET` requests to `/staged` during this time MAY also be blocked until the activation is complete.
 
 ## Connection Status
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -4,13 +4,13 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Re-Activating Senders & Receivers
 
-If an explicit activation is performed against a Sender or Receiver, the API must request a re-application of settings to the underlying Sender or Receiver implementation whether the setting have changed or not. For example in the case of multicast Receivers it is suggested that this involves an explicit IGMP leave and join. For a Sender this may involve stopping and re-starting the stream.
+If an explicit activation is performed against a Sender or Receiver, the API MUST request a re-application of settings to the underlying Sender or Receiver implementation whether the setting have changed or not. For example in the case of multicast Receivers it is suggested that this involves an explicit IGMP leave and join. For a Sender this might involve stopping and re-starting the stream.
 
 ## Transport Files & Caching
 
-It is strongly recommended that the following caching headers are included via the /transportfile endpoint (or whatever this endpoint redirects to).
+It is STRONGLY RECOMMENDED that the following caching headers are included via the /transportfile endpoint (or whatever this endpoint redirects to).
 
-```
+```http
 Cache-Control: no-cache
 ```
 
@@ -18,23 +18,22 @@ This is important to ensure that connection management clients do not cache the 
 
 ## Multi-Client Operation
 
-In environments where multiple clients may be operating against a single Connection Management API, it is possible that staging of parameters may result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients should examine the results of HTTP PATCH operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
+In environments where multiple clients might be operating against a single Connection Management API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP PATCH operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
 
 ## In-Progress Activations
 
-When an implementation is in the process of activating a new set of transport parameters, concurrent requests to the API from other clients may result in unexpected results. In order to minimise these cases, implementations are recommended to adopt the following practice:
+When an implementation is in the process of activating a new set of transport parameters, concurrent requests to the API from other clients could result in unexpected results. In order to minimise these cases, implementations are RECOMMENDED to adopt the following practice:
 
-While an activation is in progress, concurrent GET requests to the `/active` resource SHOULD reflect the current configuration of the Sender or Receiver as accurately as possible at the instant of the request.
-
-If an API implementation receives a new PATCH request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any GET requests to `/staged` during this time MAY also be blocked until the activation is complete.
+- While an activation is in progress, concurrent GET requests to the `/active` resource SHOULD reflect the current configuration of the Sender or Receiver as accurately as possible at the instant of the request.
+- If an API implementation receives a new PATCH request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any GET requests to `/staged` during this time MAY also be blocked until the activation is complete.
 
 ## Connection Status
 
-The Connection Management API does not take any responsibility for monitoring the status of a connection between a Sender and a Receiver, for example whether a Receiver is currently receiving packets. As such a loss of packets at a connectionless Receiver (e.g. UDP) or a recoverable error on a connection-oriented transport (e.g. TCP) MUST NOT be indicated via changes to the `/active` resource. Where a connection-oriented transport encounters a recoverable error (such as a broken connection or timeout), the underlying Sender or Receiver SHOULD attempt to recover from the error unless otherwise configured not to do so. This may involve the use of exponential backoff up to a defined limit. Where a Sender or Receiver is permanently unable to recover a connection-oriented transport without user interaction, for example due to erroneous configuration which was not identified prior to activation, the implementation MAY choose to reflect this into the `/active` resource by setting `master_enable` to false.
+The Connection Management API does not take any responsibility for monitoring the status of a connection between a Sender and a Receiver, for example whether a Receiver is currently receiving packets. As such a loss of packets at a connectionless Receiver (e.g. UDP) or a recoverable error on a connection-oriented transport (e.g. TCP) MUST NOT be indicated via changes to the `/active` resource. Where a connection-oriented transport encounters a recoverable error (such as a broken connection or timeout), the underlying Sender or Receiver SHOULD attempt to recover from the error unless otherwise configured not to do so. This could involve the use of exponential backoff up to a defined limit. Where a Sender or Receiver is permanently unable to recover a connection-oriented transport without user interaction, for example due to erroneous configuration which was not identified prior to activation, the implementation MAY set `master_enable` to `false` in the `/active` resource.
 
 ## 'Salvo' Operation
 
-Where a server implementation supports concurrent application of settings changes to underlying Senders and Receivers, it may choose to perform 'bulk' resource operations in a parallel fashion internally. This is an implementation decision and is not a requirement of this specification.
+Where a server implementation supports concurrent application of settings changes to underlying Senders and Receivers, it could choose to perform 'bulk' resource operations in a parallel fashion internally. This is an implementation decision and is not a requirement of this specification.
 
 If a 'bulk' request includes multiple sets of parameters for the same Sender or Receiver ID the behaviour is defined by the implementation. In order to maximise interoperability clients are encouraged not to include the same Sender or Receiver ID multiple times in the same 'bulk' request.
 
@@ -42,16 +41,16 @@ If a 'bulk' request includes multiple sets of parameters for the same Sender or 
 
 IS-05 provides a mechanism whereby the activation of staged transport parameters can be performed at a particular TAI time, or after a given interval.
 
-The primary use case for this behaviour is to allow the synchronisation of large salvo operations, where multiple pieces of equipment should carry out a change in transport parameters simultaneously. A controller may stage parameters with multiple IS-05 APIs with the same activation timestamp, and know that activation will occur at the same time on all devices regardless of the latency between the controller and the device. It is not intended to act as a mechanism for scheduling activations far in the future.
+The primary use case for this behaviour is to allow the synchronisation of large salvo operations, where multiple systems carry out a change in transport parameters simultaneously. A controller will stage parameters with multiple IS-05 APIs with the same activation timestamp, and know that activation will occur at the same time on all devices regardless of the latency between the controller and the device. It is not intended to act as a mechanism for scheduling activations far in the future.
 
-In the event of an error occurring between scheduling an activation and the activation time, the IS-05 transport parameters should reflect the current configuration of the device. For example, if a sender is no longer sending data at all it should reflect this by setting `master_enable` to false.
+In the event of an error occurring between scheduling an activation and the activation time, the IS-05 transport parameters SHOULD reflect the current configuration of the device. For example, if a sender is no longer sending data at all it would set `master_enable` to `false`.
 
-API clients should check back with the API after the expected activation time to ensure activations have completed successfully, and that the device is in the expected state. Note that a client may normally expect to see a change in the IS-04 version timestamp upon a successful update of transport parameters, and should monitor for this version timestamp update via the IS-04 web-socket where IS-05 is being used along-side IS-04.
+API clients SHOULD check back with the API after the expected activation time to ensure activations have completed successfully, and that the device is in the expected state. Note that a client would normally expect to see a change in the IS-04 version timestamp upon a successful update of transport parameters, and SHOULD monitor for this version timestamp update via the IS-04 web-socket where IS-05 is being used along-side IS-04.
 
 ## Externally Defined Parameters
 
 IS-05 aims to provide a defined core set of parameters for each supported transport type. These parameters are based upon the standard(s) which define the transport type.
 
-In some cases it may be necessary to advertise and accept additional parameters in order to make a connection, for example where an external specification extends an existing transport type in order to fulfil its own requirements. Where this is necessary, IS-05 provides the capability to define additional transport paramaters which use the prefix `ext_`. These transport parameters are governed by the same constraints structure as any other parameter, but are intended to make IS-05 more extensible for these use cases.
+In some cases it is necessary to advertise and accept additional parameters in order to make a connection, for example where an external specification extends an existing transport type in order to fulfil its own requirements. In such cases, IS-05 provides the capability to define additional transport parameters which use the prefix `ext_`. These transport parameters are governed by the same constraints structure as any other parameter, but are intended to make IS-05 more extensible for these use cases.
 
-Where `ext_` parameters are utilised, their naming, usage and versioning is defined external to IS-05. Clients which are unaware of these external definitions should ignore the presence of the parameter(s) if they need to interact with API endpoints which make use of them.
+Where `ext_` parameters are utilised, their naming, usage and versioning is defined externally to IS-05. Clients SHOULD ignore any such parameters they do not recognise.

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -8,7 +8,7 @@ If an explicit activation is performed against a Sender or Receiver, the API MUS
 
 ## Transport Files & Caching
 
-It is STRONGLY RECOMMENDED that the following caching headers are included via the `/transportfile` endpoint (or whatever this endpoint redirects to).
+It is strongly RECOMMENDED that the following caching headers are included via the `/transportfile` endpoint (or whatever this endpoint redirects to).
 
 ```http
 Cache-Control: no-cache

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -175,7 +175,7 @@ a=rtpmap:103 raw/90000
 
 SMPTE 2022-5 describes RTP streams with forward error correction (FEC), and is supported by the Connection Management Specification. This support takes the form of the FEC transport parameter set described in [Parameter Sets](#parameter-sets). Note that Senders have additional parameters used to specify the type of FEC to be used and matrix rows and columns, which are not present on the Receiver side. In SMPTE 2022-5 this information is conveyed in the FEC stream headers, and as such does not need to be conveyed separately in Connection Management.
 
-Connection Management APIs supporting SMPTE 2022-5 MUST comply with RFC 6364 when creating and interpreting SDP files. Implementers are advised to consider the guidance given in VSF TR-04. An example SDP file from RFC 6364 is shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
+Connection APIs supporting SMPTE 2022-5 MUST comply with RFC 6364 when creating and interpreting SDP files. Implementers are advised to consider the guidance given in VSF TR-04. An example SDP file from RFC 6364 is shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
 
 ```
 v=0
@@ -223,7 +223,7 @@ Where a Receiver does not support SMPTE 2022-7 but receives a SMPTE 2022-7 trans
 
 In all cases, if a client request includes `transport_params`, it MUST have the same number of array elements (or 'legs') as specified in the constraints. If no changes are needed to a specific leg it MUST be included as an empty object (`{}`).
 
-Connection Management APIs supporting SMPTE 2022-7 MUST comply with RFC 7104 when creating and interpreting SDP files. Implementers are advised to consider the guidance given in VSF TR-04. The stream listed first in the SDP file SHOULD be interpreted as being Path 1, and be populated to the first transport parameter object in `/staged`, with the inverse being true for Path 2.
+Connection APIs supporting SMPTE 2022-7 MUST comply with RFC 7104 when creating and interpreting SDP files. Implementers are advised to consider the guidance given in VSF TR-04. The stream listed first in the SDP file SHOULD be interpreted as being Path 1, and be populated to the first transport parameter object in `/staged`, with the inverse being true for Path 2.
 
 The three examples given in RFC 7104 are shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
 

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -4,96 +4,96 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Transport File Resource
 
-The Sender `/transportfile` resource should use the following HTTP header when returning the transport file:
+The Sender `/transportfile` resource SHOULD use the following HTTP header when returning the transport file:
 
 `Content-Type: application/sdp`
 
 ## Parameter Sets
 
-Senders and Receiver Connection Management endpoints must support a core parameter set. In addition they may support multicast, FEC and/or RTCP parameter sets. Endpoints must support all parameters in a parameter set, or none at all.
+Senders and Receiver Connection Management endpoints MUST support a core parameter set. In addition they MAY support multicast, FEC and/or RTCP parameter sets. Endpoints MUST support all parameters in a parameter set, or none at all.
 
 ### Receiver Parameter Sets
 
 #### Core Parameters
 
-*   `source_ip`
-*   `interface_ip`
-*   `destination_port`
-*   `rtp_enabled`
+- `source_ip`
+- `interface_ip`
+- `destination_port`
+- `rtp_enabled`
 
 #### Multicast Parameters
 
-*   `multicast_ip`
+- `multicast_ip`
 
 #### FEC Parameters
 
-*   `fec_enabled`
-*   `fec_destination_ip`
-*   `fec_mode`
-*   `fec1D_destination_port`
-*   `fec2D_destination_port`
+- `fec_enabled`
+- `fec_destination_ip`
+- `fec_mode`
+- `fec1D_destination_port`
+- `fec2D_destination_port`
 
 #### RTCP Parameters
 
-*   `rtcp_enabled`
-*   `rtcp_destination_ip`
-*   `rtcp_destination_port`
+- `rtcp_enabled`
+- `rtcp_destination_ip`
+- `rtcp_destination_port`
 
 ### Sender Parameter Sets
 
 #### Core Parameters
 
-*   `source_ip`
-*   `destination_ip`
-*   `source_port`
-*   `destination_port`
-*   `rtp_enabled`
+- `source_ip`
+- `destination_ip`
+- `source_port`
+- `destination_port`
+- `rtp_enabled`
 
 #### FEC Parameters
 
-*   `fec_enabled`
-*   `fec_destination_ip`
-*   `fec_type`
-*   `fec_mode`
-*   `fec_block_width`
-*   `fec_block_height`
-*   `fec1D_destination_port`
-*   `fec2D_destination_port`
-*   `fec1D_source_port`
-*   `fec2D_source_port`
+- `fec_enabled`
+- `fec_destination_ip`
+- `fec_type`
+- `fec_mode`
+- `fec_block_width`
+- `fec_block_height`
+- `fec1D_destination_port`
+- `fec2D_destination_port`
+- `fec1D_source_port`
+- `fec2D_source_port`
 
 #### RTCP Parameters
 
-*   `rtcp_enabled`
-*   `rtcp_destination_ip`
-*   `rtcp_destination_port`
-*   `rtcp_source_port`
+- `rtcp_enabled`
+- `rtcp_destination_ip`
+- `rtcp_destination_port`
+- `rtcp_source_port`
 
 ## Use of auto
 
-Parameters which support use of `auto` are identified in the schemas. Where it is unclear how `auto` should be interpreted this is noted below.
+Parameters which support use of `auto` are identified in the schemas. This section clarifies the use of `auto` in some cases that might be unclear.
 
 ### Sender `source_ip` and Receiver `interface_ip`
 
-These parameters specify the interface binding to use for sending or receiving traffic. Use of `auto` here implies the Device should determine for itself which of its interfaces is the most appropriate to use. In Devices where only one interface is available for media traffic this is trivial. In Devices with multiple media network interfaces Devices may use mechanisms such as routing tables, out-of-band controls or evaluation of loading on the interfaces.
+These parameters specify the interface binding to use for sending or receiving traffic. Use of `auto` here means the Device SHOULD determine for itself which of its interfaces is the most appropriate to use. In Devices where only one interface is available for media traffic this is trivial. In Devices with multiple media network interfaces Devices could use mechanisms such as routing tables, out-of-band controls or evaluation of loading on the interfaces.
 
 ### Sender `destination_ip`
 
-If this parameter is set to auto the Sender is expected to automatically select an address to send on. This may be determined by an external network control system, or through technologies such as MADCAP (RFC 2730) or ZMAAP.
+If this parameter is set to auto the Sender is expected to automatically select an address to send on. This could be determined by an external network control system, or through technologies such as MADCAP (RFC 2730) or ZMAAP.
 
 ## Behaviour of SDP Media Information
 
-SDP files contain both connection information and media information. When a parameter set is activated with an SDP file present in `data` the Receiver should use the media information in the SDP file.
+SDP files contain both connection information and media information. When a parameter set is activated with an SDP file present in `data` the Receiver SHOULD use the media information in the SDP file.
 
 ## Interpretation of SDP Files
 
-All Senders and Receivers should comply with RFC 4566 (Session Description Protocol) when creating and parsing SDP files. Multicast Senders and Receivers should additionally comply with RFC 4570 (SDP Source Filters). Three examples are given below, showing an SDP file and the transport parameters that would be presented at the `/staged` endpoint by a single-legged Receiver that has parsed the file.
+All Senders and Receivers SHOULD comply with RFC 4566 (Session Description Protocol) when creating and parsing SDP files. Multicast Senders and Receivers SHOULD additionally comply with RFC 4570 (SDP Source Filters). Three examples are given below, showing an SDP file and the transport parameters that would be presented at the `/staged` endpoint by a single-legged Receiver that has parsed the file.
 
 A Receiver sets the `rtp_enabled` parameter to true for each leg it has configured from the SDP file, unless overridden by the requested `transport_params` as noted below.
 
 In the event that a Receiver is presented with an SDP file and a set of transport parameters that
 contradict each other in the same PATCH request, the transport parameters take priority
-over the SDP file and must be the parameters used for activation. This only applies
+over the SDP file and MUST be the parameters used for activation. This only applies
 in the case where there is contradiction between the SDP file and transport parameters within
 a single PATCH request, in all other cases the most recently received PATCH request takes priority.
 
@@ -175,7 +175,7 @@ a=rtpmap:103 raw/90000
 
 SMPTE 2022-5 describes RTP streams with forward error correction (FEC), and is supported by the Connection Management Specification. This support takes the form of the FEC transport parameter set described in [Parameter Sets](#parameter-sets). Note that Senders have additional parameters used to specify the type of FEC to be used and matrix rows and columns, which are not present on the Receiver side. In SMPTE 2022-5 this information is conveyed in the FEC stream headers, and as such does not need to be conveyed separately in Connection Management.
 
-Connection Management APIs supporting SMPTE 2022-5 must comply with RFC 6364 when creating and interpreting SDP files. Implementers may wish to consider the guidance given in VSF TR-04. An example SDP file from RFC 6364 is shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
+Connection Management APIs supporting SMPTE 2022-5 MUST comply with RFC 6364 when creating and interpreting SDP files. Implementers are advised to consider the guidance given in VSF TR-04. An example SDP file from RFC 6364 is shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
 
 ```
 v=0
@@ -215,15 +215,15 @@ a=mid:R1
 
 SMPTE 2022-7 describes redundant streams for RTP connections, and is supported by the Connection Management Specification. This manifests itself in the fact that the JSON which describes constraints and transport parameters resides within an array. Where SMPTE-2022-7 is not supported this array contains only one object. Where SMPTE-2022-7 is supported the array contains two entries. The first entry contains information pertaining to Path 1, the second information pertaining to Path 2.
 
-Where a Receiver supports SMPTE 2022-7 but receives a request with a non-SMPTE 2022-7 transport file, the Receiver should set `rtp_enabled` in the second set of parameters to false and transport parameters in the SDP file should be mapped onto that first set of parameters in the array with `rtp_enabled` set to true (bearing in mind that the `transport_params` values in the same request take priority).
+Where a Receiver supports SMPTE 2022-7 but receives a request with a non-SMPTE 2022-7 transport file, the Receiver SHOULD set `rtp_enabled` in the second set of parameters to `false` and transport parameters in the SDP file SHOULD be mapped onto that first set of parameters in the array with `rtp_enabled` set to `true` (bearing in mind that the `transport_params` values in the same request take priority).
 
-Where a client request does not include a transport file and uses only `transport_params` to configure such a Receiver for a non-SMPTE 2022-7 stream, the request should explicitly set `rtp_enabled` in the second set of parameters to false.
+Where a client request does not include a transport file and uses only `transport_params` to configure such a Receiver for a non-SMPTE 2022-7 stream, the request SHOULD explicitly set `rtp_enabled` in the second set of parameters to `false`.
 
-Where a Receiver does not support SMPTE 2022-7 but receives a SMPTE 2022-7 transport file containing two sets of transport parameters it is recommended that it parses the first set of transport parameters found in the file and joins the stream as if it were a non-SMPTE 2022-7 stream. This ensures compatibility with Senders which do not support operation in a non-SMPTE 2022-7 mode.
+Where a Receiver does not support SMPTE 2022-7 but receives a SMPTE 2022-7 transport file containing two sets of transport parameters it is RECOMMENDED that it parses the first set of transport parameters found in the file and joins the stream as if it were a non-SMPTE 2022-7 stream. This ensures compatibility with Senders which do not support operation in a non-SMPTE 2022-7 mode.
 
-In all cases, if a client request includes `transport_params`, it must have the same number of array elements (or 'legs') as specified in the constraints. If no changes are required to a specific leg it must be included as an empty object (`{}`).
+In all cases, if a client request includes `transport_params`, it MUST have the same number of array elements (or 'legs') as specified in the constraints. If no changes are needed to a specific leg it MUST be included as an empty object (`{}`).
 
-Connection Management APIs supporting SMPTE 2022-7 must comply with RFC 7104 when creating and interpreting SDP files. Implementers may also wish to consider the guidance given in VSF TR-04. The stream listed first in the SDP file should be interpreted as being Path 1, and be populated to the first transport parameter object in `/staged`, with the inverse being true for Path 2.
+Connection Management APIs supporting SMPTE 2022-7 MUST comply with RFC 7104 when creating and interpreting SDP files. Implementers are advised to consider the guidance given in VSF TR-04. The stream listed first in the SDP file SHOULD be interpreted as being Path 1, and be populated to the first transport parameter object in `/staged`, with the inverse being true for Path 2.
 
 The three examples given in RFC 7104 are shown below, followed by the transport parameters that would be presented on the `/staged` endpoint by a Receiver that has parsed the file.
 
@@ -338,9 +338,9 @@ a=mid:Ch1
 
 ## Operation with RTCP
 
-RTCP provides various functions to support the operation of RTP, principally QoS reporting. RTCP is defined in Section 6 of RFC 3550, which suggests the next highest odd port after the RTP port should be used for its transmission. Where RTCP and forward error correction are both in use the RTP port should be chosen to be even, to satisfy the recommendations of both RFC 3550 and SMPTE 2022-5 without resulting in port collisions.
+RTCP provides various functions to support the operation of RTP, principally QoS reporting. RTCP is defined in Section 6 of RFC 3550, which suggests that the next highest odd port after the RTP port is used for its transmission. Where RTCP and forward error correction are both in use the RTP port SHOULD be chosen to be even, to satisfy the recommendations of both RFC 3550 and SMPTE 2022-5 without resulting in port collisions.
 
-Senders and Receivers supporting RTCP should comply with RFC 3605 when creating and receiving SDP files. An RFC 3605 compliant SDP files are shown below, along with the transport parameters that would be presented on the `/staged` endpoint by a Receiver that had just parsed that file.
+Senders and Receivers supporting RTCP SHOULD comply with RFC 3605 when creating and receiving SDP files. An RFC 3605 compliant SDP files are shown below, along with the transport parameters that would be presented on the `/staged` endpoint by a Receiver that had just parsed that file.
 
 ```
 v=0

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -92,10 +92,10 @@ All Senders and Receivers SHOULD comply with RFC 4566 (Session Description Proto
 A Receiver sets the `rtp_enabled` parameter to true for each leg it has configured from the SDP file, unless overridden by the requested `transport_params` as noted below.
 
 In the event that a Receiver is presented with an SDP file and a set of transport parameters that
-contradict each other in the same PATCH request, the transport parameters take priority
+contradict each other in the same `PATCH` request, the transport parameters take priority
 over the SDP file and MUST be the parameters used for activation. This only applies
 in the case where there is contradiction between the SDP file and transport parameters within
-a single PATCH request, in all other cases the most recently received PATCH request takes priority.
+a single `PATCH` request, in all other cases the most recently received `PATCH` request takes priority.
 
 ### Unicast
 

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -4,33 +4,33 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Transport File Resource
 
-The Sender `/transportfile` resource should not be used for this transport type. This resource should return a 404 error code if requested.
+The Sender `/transportfile` resource SHOULD NOT be used for this transport type. This resource SHOULD return a 404 error code if requested.
 
 ## Parameter Sets
 
-Senders and Receiver Connection Management endpoints must support a core parameter set as follows.
+Senders and Receiver Connection Management endpoints MUST support a core parameter set as follows.
 
 ### Receiver Parameter Sets
 
 #### Core Parameters
 
-*   `source_host`
-*   `source_port`
-*   `broker_topic`
-*   `broker_protocol`
-*   `broker_authorization`
-*   `connection_status_broker_topic`
+- `source_host`
+- `source_port`
+- `broker_topic`
+- `broker_protocol`
+- `broker_authorization`
+- `connection_status_broker_topic`
 
 ### Sender Parameter Sets
 
 #### Core Parameters
 
-*   `destination_host`
-*   `destination_port`
-*   `broker_topic`
-*   `broker_protocol`
-*   `broker_authorization`
-*   `connection_status_broker_topic`
+- `destination_host`
+- `destination_port`
+- `broker_topic`
+- `broker_protocol`
+- `broker_authorization`
+- `connection_status_broker_topic`
 
 ## Use of auto
 

--- a/docs/4.2. Behaviour - MQTT Transport Type.md
+++ b/docs/4.2. Behaviour - MQTT Transport Type.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Transport File Resource
 
-The Sender `/transportfile` resource SHOULD NOT be used for this transport type. This resource SHOULD return a 404 error code if requested.
+The Sender `/transportfile` resource SHOULD NOT be used for this transport type. This resource SHOULD return a `404` (Not Found) error code if requested.
 
 ## Parameter Sets
 

--- a/docs/4.3. Behaviour - WebSocket Transport Type.md
+++ b/docs/4.3. Behaviour - WebSocket Transport Type.md
@@ -4,25 +4,25 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Transport File Resource
 
-The Sender `/transportfile` resource should not be used for this transport type. This resource should return a 404 error code if requested.
+The Sender `/transportfile` resource SHOULD NOT be used for this transport type. This resource SHOULD return a 404 error code if requested.
 
 ## Parameter Sets
 
-Senders and Receiver Connection Management endpoints must support a core parameter set as follows.
+Senders and Receiver Connection Management endpoints MUST support a core parameter set as follows.
 
 ### Receiver Parameter Sets
 
 #### Core Parameters
 
-*   `connection_uri`
-*   `connection_authorization`
+- `connection_uri`
+- `connection_authorization`
 
 ### Sender Parameter Sets
 
 #### Core Parameters
 
-*   `connection_uri`
-*   `connection_authorization`
+- `connection_uri`
+- `connection_authorization`
 
 ## Use of auto
 

--- a/docs/4.3. Behaviour - WebSocket Transport Type.md
+++ b/docs/4.3. Behaviour - WebSocket Transport Type.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Transport File Resource
 
-The Sender `/transportfile` resource SHOULD NOT be used for this transport type. This resource SHOULD return a 404 error code if requested.
+The Sender `/transportfile` resource SHOULD NOT be used for this transport type. This resource SHOULD return a `404` (Not Found) error code if requested.
 
 ## Parameter Sets
 

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -6,23 +6,23 @@ As is common with web APIs, over time changes will be made to support new use ca
 
 API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with procedures for handling upgrades described below.
 
-## Requirements for Connection Management APIs
+## Requirements for Connection APIs
 
-Implementers of the Connection Management API MUST support at least one API version, and MAY support more than one at a time.
+Implementers of the Connection API MUST support at least one API version, and MAY support more than one at a time.
 
-Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs MUST NOT list any Senders or Receivers which make use of this new transport type. In these cases, requests to an inaccessible ID MUST return a 409 HTTP code.
+Where a transport type is added in a new version of the Connection API specification, earlier versioned APIs MUST NOT list any Senders or Receivers which make use of this new transport type. In these cases, requests to an inaccessible ID MUST return a 409 HTTP code.
 
-Where new transport parameters are added to a pre-existing transport type in a new version of the Connection Management API, earlier versioned APIs MUST NOT list these parameters. New transport parameters SHOULD be defined such that a request which omits them can proceed without error. This ensures that servers implementing multiple versions of the Connection Management API can continue to process earlier versioned requests successfully.
+Where new transport parameters are added to a pre-existing transport type in a new version of the Connection API, earlier versioned APIs MUST NOT list these parameters. New transport parameters SHOULD be defined such that a request which omits them can proceed without error. This ensures that servers implementing multiple versions of the Connection API can continue to process earlier versioned requests successfully.
 
-Connection Management APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas.
+Connection APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas.
 
 ## Requirements for Connection Management clients
 
-Implementers of Connection Management clients are strongly RECOMMENDED to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
+Implementers of Connection Management clients are strongly RECOMMENDED to support multiple versions of the Connection API simultaneously in order to ease the upgrade process in live facilities.
 
 ## Performing Upgrades
 
 The following procedure is suggested for a live system which needs to migrate between API versions.
 
-- Upgrade API clients to their new versions, to support all Connection Management API versions you are currently using in your deployment.
-- Upgrade Connection Management API implementations to support the new API version.
+- Upgrade API clients to their new versions, to support all Connection API versions you are currently using in your deployment.
+- Upgrade Connection API implementations to support the new API version.

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -2,27 +2,27 @@
 
 _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
-As is common with web APIs, over time changes will be made to support new use cases and deprecate old ways of working. The NMOS APIs are no different, and have been designed to permit in-service upgrades across a facility which may be running large amounts of equipment with support for different versions of these specifications.
+As is common with web APIs, over time changes will be made to support new use cases and deprecate old ways of working. The NMOS APIs are no different, and have been designed to permit in-service upgrades across a facility which could be running large amounts of equipment with support for different versions of these specifications.
 
 API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with procedures for handling upgrades described below.
 
 ## Requirements for Connection Management APIs
 
-Implementers of the Connection Management API must support at least one API version, and may support more than one at a time.
+Implementers of the Connection Management API MUST support at least one API version, and MAY support more than one at a time.
 
-Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs must not list any Senders or Receivers which make use of this new transport type. In these cases, requests to an inaccessible ID MUST return a 409 HTTP code.
+Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs MUST NOT list any Senders or Receivers which make use of this new transport type. In these cases, requests to an inaccessible ID MUST return a 409 HTTP code.
 
-Where new transport parameters are added to a pre-existing transport type in a new version of the Connection Management API, earlier versioned APIs must not list these parameters. New transport parameters should be defined such that a request which omits them can proceed without error. This ensures that servers implementing multiple versions of the Connection Management API can continue to process earlier versioned requests successfully.
+Where new transport parameters are added to a pre-existing transport type in a new version of the Connection Management API, earlier versioned APIs MUST NOT list these parameters. New transport parameters SHOULD be defined such that a request which omits them can proceed without error. This ensures that servers implementing multiple versions of the Connection Management API can continue to process earlier versioned requests successfully.
 
-Connection Management APIs are not required to provide for forwards compatibility as it may be impossible to generate data for new attributes in schemas.
+Connection Management APIs do not need to provide for forwards compatibility as it might be impossible to generate data for new attributes in schemas.
 
 ## Requirements for Connection Management clients
 
-Implementers of Connection Management clients are strongly recommended to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
+Implementers of Connection Management clients are STRONGLY RECOMMENDED to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
 
 ## Performing Upgrades
 
 The following procedure is suggested for a live system which needs to migrate between API versions.
 
-*   Upgrade API clients to their new versions, which must support all Connection Management API versions you are currently using in your deployment.
-*   Upgrade Connection Management API implementations to support the new API version.
+- Upgrade API clients to their new versions, to support all Connection Management API versions you are currently using in your deployment.
+- Upgrade Connection Management API implementations to support the new API version.

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -10,7 +10,7 @@ API versioning is specified in the [APIs](2.0.%20APIs.md) documentation, with pr
 
 Implementers of the Connection Management API MUST support at least one API version, and MAY support more than one at a time.
 
-Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs MUST NOT list any Senders or Receivers which make use of this new transport type. In these cases, requests to an inaccessible ID MUST return a 409 HTTP code.
+Where a transport type is added in a new version of the Connection Management API specification, earlier versioned APIs MUST NOT list any Senders or Receivers which make use of this new transport type. In these cases, requests to an inaccessible ID MUST return a `409` (Conflict) HTTP code.
 
 Where new transport parameters are added to a pre-existing transport type in a new version of the Connection Management API, earlier versioned APIs MUST NOT list these parameters. New transport parameters SHOULD be defined such that a request which omits them can proceed without error. This ensures that servers implementing multiple versions of the Connection Management API can continue to process earlier versioned requests successfully.
 

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -18,7 +18,7 @@ Connection Management APIs do not need to provide for forwards compatibility as 
 
 ## Requirements for Connection Management clients
 
-Implementers of Connection Management clients are STRONGLY RECOMMENDED to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
+Implementers of Connection Management clients are strongly RECOMMENDED to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
 
 ## Performing Upgrades
 

--- a/examples/receiver-active-get-200-mqtt.json
+++ b/examples/receiver-active-get-200-mqtt.json
@@ -11,7 +11,7 @@
     "type": null
   },
   "transport_params": [{
-    "source_host": "broker.mydomain.com",
+    "source_host": "broker.example.com",
     "source_port": 1883,
     "broker_topic": "my_topic_name",
     "broker_protocol": "mqtt",

--- a/examples/sender-active-get-mqtt.json
+++ b/examples/sender-active-get-mqtt.json
@@ -7,7 +7,7 @@
     "activation_time": "1541508905:0"
   },
   "transport_params": [{
-    "destination_host": "broker.mydomain.com",
+    "destination_host": "broker.example.com",
     "destination_port": 1883,
     "broker_topic": "my_topic_name",
     "broker_protocol": "mqtt",


### PR DESCRIPTION
  Normative terms (MUST, SHOULD, MAY, etc.) are now all capitalised. Non-
  normative uses of those terms (which were mostly lower-case) have been
  replaced or rephrased.

  Some other language improvements and a little reformatting, but more is needed.