### PR TITLE
Use backticks to render URLs etc as monospaced

### DIFF
--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -1,6 +1,10 @@
 # AMWA IS-05 NMOS Device Connection Management Specification: Overview
+{:.no_toc}
 
-_(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
+- A markdown unordered list which will be replaced with the ToC, excluding the "Contents header" from above
+{:toc}
+
+<!-- _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_  -->
 
 ## Introduction
 
@@ -38,15 +42,15 @@ Restrictions associated with each parameter which is defined for a given transpo
 
 #### Staged
 
-The `staged` endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
+The `/staged` endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
 
 #### Active
 
-The `active` endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of staged settings is activated, these settings transition into the `active` resource.
+The `/active` endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of staged settings is activated, these settings transition into the `/active` resource.
 
 #### Transport File
 
-Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the `transportfile` endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
+Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the `/transportfile` endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
 
 #### Transport Type
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Introduction
 
-AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices` Senders and Receivers.
+AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices' Senders and Receivers.
 
 The Specification includes:
 

--- a/docs/1.0. Overview.md
+++ b/docs/1.0. Overview.md
@@ -4,7 +4,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 ## Introduction
 
-AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices' Senders and Receivers.
+AMWA IS-05 specifies how to allow a Device in an NMOS compatible system to connect to other Devices, by means of the Devices` Senders and Receivers.
 
 The Specification includes:
 
@@ -38,15 +38,15 @@ Restrictions associated with each parameter which is defined for a given transpo
 
 #### Staged
 
-The staged endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
+The `staged` endpoint provides the means to make changes to settings associated with a Sender or Receiver. These changes can be applied to the underlying implementation immediately, or at a time offset signalled in the HTTP request.
 
 #### Active
 
-The active endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of 'staged' settings is activated, these settings transition into the 'active' resource.
+The `active` endpoint reflects the current running configuration of the underlying Sender or Receiver. When a set of staged settings is activated, these settings transition into the `active` resource.
 
 #### Transport File
 
-Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the 'transportfile' endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
+Where a transport protocol is accompanied by file format which advertises connection parameters, this can be exposed via the `transportfile` endpoint of a Sender. This provides the means to expose a Session Description Protocol (SDP) file in the case of RTP for example.
 
 #### Transport Type
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -19,7 +19,7 @@ JSON schemas are included with the RAML API definitions. These include validatio
 
 ### Content Types
 
-All APIs MUST provide a JSON representation signalled via 'Content-Type: application/json' headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
+All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
 
 ### API Paths
 
@@ -39,7 +39,7 @@ Where protocol and versioning data is not available, clients MAY assume a v1.0 A
 
 All public APIs are versioned as follows:
 
-- Requesting the API base resource (such as http(s)://&lt;ip address or hostname&gt;:&lt;port&gt;/x-nmos/query/) will provide a list containing the versions of the API present on the node.
+- Requesting the API base resource (such as `http(s)://<ip address or hostname>:<port>/x-nmos/query/`) will provide a list containing the versions of the API present on the node.
 - A versioned API response MUST include only resources which match the schema for that API version.
 - Data which is held for mismatched minor API versions MAY be returned if it can be conformed to the correct schema (see example below). Data MUST NOT be conformed between major API versions.
 
@@ -60,11 +60,11 @@ A v1.1 API response can include:
 ]
 ```
 
-- Appending /v1.0/ to the API base resource will request version 1.0 of the API if available.
-- The versioning format is v&lt;#MAJOR&gt;.&lt;#MINOR&gt;
+- Appending `/v1.0/` to the API base resource will request version 1.0 of the API if available.
+- The versioning format is `v<#MAJOR>.<#MINOR>`
 - MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
 - MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
-- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (.) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
 - Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes
@@ -88,7 +88,7 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 #### Client Behaviour
 
-When a server implementation needs to indicate an API URL via an 'href' or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to 'href' type attributes MUST support both cases, avoiding doubled or missing slashes.
+When a server implementation needs to indicate an API URL via an `href` or similar attribute, it is valid to either include a trailing slash or not provided that the listed path is accessible and follows the above rules. Clients appending paths to `href` type attributes MUST support both cases, avoiding doubled or missing slashes.
 
 ### Error Codes & Responses
 
@@ -106,6 +106,6 @@ For HTTP codes 400 and upwards, a JSON format response MUST be returned as follo
 }
 ```
 
-In the above example, the 'code' SHOULD match the HTTP status code. 'error' MUST always be present and in string format. 'debug' MAY be null if no further debug information is available.
+In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be null if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -15,7 +15,7 @@ Examples of JSON format output are provided in the [examples](../examples/) fold
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a `400` (Bad Request) HTTP status to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Connection API use these JSON schemas as part of a validation stage when receiving requests from clients. Invalid resources SHOULD cause a `400` (Bad Request) HTTP error to be returned to the client.
 
 ### Content Types
 
@@ -23,23 +23,19 @@ All APIs MUST provide a JSON representation signalled via `Content-Type: applica
 
 ### API Paths
 
-All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the /x-nmos/ path as follows:
+All NMOS APIs MUST use a path in the following format. Other HTTP resources MAY be presented on the same port by the Node, provided all NMOS resources are available from the `/x-nmos/` path as follows:
 
-```json
+```
 http(s)://<ip address or hostname>:<port>/x-nmos/<api type>/<api version>/
 ```
 
 At each level of the API from the base resource upwards, the response SHOULD include a JSON format array of the child resources available from that point.
 
-API clients using DNS-SD for API discovery SHOULD construct these paths by making use of the TXT records 'api\_proto' and 'api\_ver', along with addresses and ports resolved via DNS-SD. API clients which are discovering Node APIs via a Query API SHOULD construct Node API paths using the corresponding data available within the \'api\' attributes within the Query API /nodes/ path.
-
-Where protocol and versioning data is not available, clients MAY assume a v1.0 API, which operates via the 'http' protocol only.
-
 ### Versioning
 
 All public APIs are versioned as follows:
 
-- Requesting the API base resource (such as `http(s)://<ip address or hostname>:<port>/x-nmos/query/`) will provide a list containing the versions of the API present on the node.
+- Requesting the API base resource (such as `http(s)://<ip address or hostname>:<port>/x-nmos/connection/`) will provide a list containing the versions of the API present on the node.
 - A versioned API response MUST include only resources which match the schema for that API version.
 - Data which is held for mismatched minor API versions MAY be returned if it can be conformed to the correct schema (see example below). Data MUST NOT be conformed between major API versions.
 
@@ -60,11 +56,11 @@ A v1.1 API response can include:
 ]
 ```
 
-- Appending `/v1.0/` to the API base resource will request version 1.0 of the API if available.
-- The versioning format is `v<#MAJOR>.<#MINOR>`
-- MINOR increments SHOULD be performed for non-breaking changes (such as the addition of attributes in a response)
-- MAJOR increments MUST be performed for breaking changes (such as the renaming of a resource or attribute)
-- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of MAJOR, MINOR version (such that v1.12 is greater than v1.5).
+- Appending `/v1.0/` to the API base resource will request the version v1.0 of the API if available.
+- The versioning format is `v<MAJOR>.<MINOR>`
+- `MINOR` increments will be performed for non-breaking changes (such as the addition of attributes in a response)
+- `MAJOR` increments will be performed for breaking changes (such as the renaming of a resource or attribute)
+- Versions MUST be represented as complete strings. Parsing MUST proceed as follows: separate into two strings, using the point (`.`) as a delimiter. Compare integer representations of `MAJOR`, `MINOR` version (such that v1.12 is greater than v1.5).
 - Clients are responsible for identifying the correct API version they require.
 
 ### URLs: Approach to Trailing Slashes
@@ -106,6 +102,6 @@ For HTTP codes `400` and upwards, a JSON format response MUST be returned as fol
 }
 ```
 
-In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
+`code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -19,7 +19,7 @@ JSON schemas are included with the RAML API definitions. These include validatio
 
 ### Content Types
 
-All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via Accept headers.
+All APIs MUST provide a JSON representation signalled via `Content-Type: application/json` headers. This SHOULD be the default content type in the absence of any requested alternative by clients. Other content types (such as HTML) are permitted if they are explicitly requested via `Accept` headers.
 
 ### API Paths
 
@@ -106,6 +106,6 @@ For HTTP codes `400` and upwards, a JSON format response MUST be returned as fol
 }
 ```
 
-In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be null if no further debug information is available.
+In the above example, `code` SHOULD match the HTTP status code. `error` MUST always be present and in string format. `debug` MAY be `null` if no further debug information is available.
 
 Further details on when APIs will respond with particular codes is covered in the [Behaviour](4.0.%20Behaviour.md) section.

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -15,7 +15,7 @@ Examples of JSON format output are provided in the [examples](../examples/) fold
 
 ## API Validation
 
-JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a 400 HTTP error (Bad Request) to be returned to the client.
+JSON schemas are included with the RAML API definitions. These include validation for values used within the APIs. It is RECOMMENDED that implementers of a Registration API use these JSON schemas as part of a validation stage when receiving registrations from Nodes. Invalid resources SHOULD cause a `400` (Bad Request) HTTP status to be returned to the client.
 
 ### Content Types
 
@@ -75,16 +75,16 @@ In order to overcome shortcomings in some common libraries, the following requir
 
 #### `GET` and `HEAD` Requests
 
-- Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
-- When a 301 is supported, the client MUST follow the redirect in order to retrieve the response payload.
-- Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
+- Clients performing requests using these methods SHOULD correctly handle a `301` (Moved Permanently) response.
+- When a `301` is supported, the client MUST follow the redirect in order to retrieve the response payload.
+- Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a `301` response causing a redirect to the other if preferred.
 
 #### All Other Requests (`PUT`, `POST`, `DELETE`, `OPTIONS`, etc.)
 
 - Clients performing requests using these methods MUST use URLs with no trailing slash present.
 - Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.
 - Servers implementing the APIs MAY correctly interpret requests using these methods to paths with trailing slashes present for backward compatibility.
-- Servers SHOULD NOT respond with 3xx codes for these request types.
+- Servers SHOULD NOT respond with `3xx` codes for these request types.
 
 #### Client Behaviour
 
@@ -92,9 +92,9 @@ When a server implementation needs to indicate an API URL via an `href` or simil
 
 ### Error Codes & Responses
 
-The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. Explicit handling of every possible HTTP response code is not expected, but clients are expected to implement generic handling for ranges of response codes (1xx, 2xx, 3xx, 4xx and 5xx).
+The NMOS APIs use HTTP status codes to indicate success, failure and other cases to clients as per [RFC 7231](https://tools.ietf.org/html/rfc7231) and related standards. Where the RAML specification of an API specifies explicit response codes it is expected that a client will handle these cases in a particular way. Explicit handling of every possible HTTP response code is not expected, but clients are expected to implement generic handling for ranges of response codes (`1xx`, `2xx`, `3xx`, `4xx` and `5xx`).
 
-For HTTP codes 400 and upwards, a JSON format response MUST be returned as follows:
+For HTTP codes `400` and upwards, a JSON format response MUST be returned as follows:
 
 **Example Error Response**
 

--- a/docs/2.0. APIs.md
+++ b/docs/2.0. APIs.md
@@ -73,13 +73,13 @@ For consistency and in order to adhere to how these APIs are specified in RAML, 
 
 In order to overcome shortcomings in some common libraries, the following requirements are imposed for the support of URL paths with or without trailing slashes.
 
-#### GET and HEAD Requests
+#### `GET` and `HEAD` Requests
 
 - Clients performing requests using these methods SHOULD correctly handle a 301 response (moved permanently).
 - When a 301 is supported, the client MUST follow the redirect in order to retrieve the response payload.
 - Servers implementing the APIs MUST support requests using these methods to both the trailing slash and non-trailing slash path to each resource. One of these MAY produce a 301 response causing a redirect to the other if preferred.
 
-#### All Other Requests (PUT, POST, DELETE, OPTIONS etc)
+#### All Other Requests (`PUT`, `POST`, `DELETE`, `OPTIONS`, etc.)
 
 - Clients performing requests using these methods MUST use URLs with no trailing slash present.
 - Servers implementing the APIs MUST correctly interpret requests using these methods to paths without trailing slashes present.

--- a/docs/2.1. APIs - Client Side Implementation.md
+++ b/docs/2.1. APIs - Client Side Implementation.md
@@ -14,6 +14,6 @@ When receiving from a (non-NMOS) Device which does not provide an SDP file, a co
 
 ## Failure Modes
 
-If a client receives an HTTP 500 response code from the API a failure has occurred and the `error` field can be used to indicate to a user that the Device might be in a bad state. In such a case the client SHOULD refresh the values in the `/staged` and `/active` endpoints to reflect the current state of the API.
+If a client receives an HTTP `500` (Internal Server Error) response code from the API a failure has occurred and the `error` field can be used to indicate to a user that the Device might be in a bad state. In such a case the client SHOULD refresh the values in the `/staged` and `/active` endpoints to reflect the current state of the API.
 
 If an activation is triggered across multiple Senders and Receivers using the `/bulk` interface, Senders and Receivers will transition to their new active parameters, even if some Senders or Receivers in the same salvo fail to activate. It is the responsibility of the client to recover from this situation if desired, including reverting Senders and Receivers that have successfully activated back to their original state where necessary.

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -8,7 +8,7 @@ In order to permit web-based control interfaces to be hosted remotely, all NMOS 
 
 In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP `OPTIONS` requests made to any other API resource.
 
-In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and might not be suitable for a production deployment.
+In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and possibly not suitable for a production deployment.
 
 ```http
 Access-Control-Allow-Origin: *
@@ -21,9 +21,9 @@ To ensure compatibility, the response `Access-Control-Allow-Headers` could be se
 
 ## Use of `.local` Hostnames
 
-Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
+Where `href` or `host` attributes are specified in the APIs, it is strongly RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames can result in Nodes appearing inaccessible.
 
-## Un-initialised Senders and Receivers
+## Uninitialised Senders and Receivers
 
 When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
@@ -44,7 +44,7 @@ In some cases the behaviour is more complex, and can be determined by the vendor
 
 ### Use of JSON Schema with Constraints
 
-It is STRONGLY RECOMMENDED that API implementations validate requests received from clients against the JSON schema included in this specification. Where additional constraints are applied by the API using the `/constraints` resource, these restrictions SHOULD be merged with the provided JSON schema in order to provide consistent validation.
+It is strongly RECOMMENDED that API implementations validate requests received from clients against the JSON schema included in this specification. Where additional constraints are applied by the API using the `/constraints` resource, these restrictions SHOULD be merged with the provided JSON schema in order to provide consistent validation.
 
 ### Constraining Interfaces
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -34,9 +34,9 @@ When a Sender or Receiver is first started it might not have all the parameters 
 
 ## Use of auto
 
-Many transport parameters MAY be set to "auto" in the `/staged` endpoint, to tell the Sender or Receiver to select the parameter for itself. In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas. For example a port number might be offset from the RTP port number by a pre-determined value. The specification makes suggestions of a sensible default value for "auto" to resolve to, but the Sender or Receiver might choose any value permitted by the schema and constraints.
+Many transport parameters MAY be set to `"auto"` in the `/staged` endpoint, to tell the Sender or Receiver to select the parameter for itself. In many cases this is a simple operation, and the behaviour is very clearly defined in the relevant transport parameter schemas. For example a port number might be offset from the RTP port number by a pre-determined value. The specification makes suggestions of a sensible default value for `"auto"` to resolve to, but the Sender or Receiver might choose any value permitted by the schema and constraints.
 
-Transport parameters which need to support "auto" are defined in the specification. Implementations SHOULD NOT indicate "auto" as an option via their `/constraints` endpoint.
+Transport parameters which need to support `"auto"` are defined in the specification. Implementations SHOULD NOT indicate `"auto"` as an option via their `/constraints` endpoint.
 
 In some cases the behaviour is more complex, and can be determined by the vendor. These cases are indicated in section 4 for the specific transport types.
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -27,8 +27,8 @@ Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECO
 
 When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
-- Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to null.
-- Senders that are not configured (for example have a null source IP address value) SHOULD return `404` (Not Found) on their active transport file endpoint, until a usable set of parameters has been activated.
+- Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to `null`.
+- Senders that are not configured (for example have a `null` source IP address value) SHOULD return `404` (Not Found) on their active transport file endpoint, until a usable set of parameters has been activated.
 
 (In other cases, Senders and Receivers might start with parameters already configured, for example through use of a configuration file or manual entry of parameters.)
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -28,7 +28,7 @@ Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECO
 When a Sender or Receiver is first started it might not have all the parameters it needs to operate. For example IP addresses and port numbers might not be set. In such cases:
 
 - Senders and Receivers SHOULD present sensible default values on transport parameter endpoints. Suggested defaults are given in the relevant schemas. Any default parameters such as port numbers specified in relevant RFCs SHOULD be followed. Parameters where no sensible defaults exist, such as source IP address on a Receiver, SHOULD be set to null.
-- Senders that are not configured (for example have a null source IP address value) SHOULD return 404 on their active transport file endpoint, until a usable set of parameters has been activated.
+- Senders that are not configured (for example have a null source IP address value) SHOULD return `404` (Not Found) on their active transport file endpoint, until a usable set of parameters has been activated.
 
 (In other cases, Senders and Receivers might start with parameters already configured, for example through use of a configuration file or manual entry of parameters.)
 

--- a/docs/2.2. APIs - Server Side Implementation.md
+++ b/docs/2.2. APIs - Server Side Implementation.md
@@ -6,7 +6,7 @@ _(c) AMWA 2017, CC Attribution-NoDerivatives 4.0 International (CC BY-ND 4.0)_
 
 In order to permit web-based control interfaces to be hosted remotely, all NMOS APIs MUST implement valid CORS HTTP headers in responses to all requests.
 
-In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight OPTIONS requests. Servers MAY additionally support HTTP OPTIONS requests made to any other API resource.
+In addition to this, where highlighted in the API specifications servers MUST respond to HTTP pre-flight `OPTIONS` requests. Servers MAY additionally support HTTP `OPTIONS` requests made to any other API resource.
 
 In order to simplify development, the following headers MAY be returned in order to remove these restrictions as far as possible. Note that these are very relaxed and might not be suitable for a production deployment.
 
@@ -17,11 +17,11 @@ Access-Control-Allow-Headers: Content-Type, Accept
 Access-Control-Max-Age: 3600
 ```
 
-To ensure compatibility, the response 'Access-Control-Allow-Headers' could be set from the request's 'Access-Control-Request-Headers'.
+To ensure compatibility, the response `Access-Control-Allow-Headers` could be set from the request's `Access-Control-Request-Headers`.
 
-## Use of '.local' Hostnames
+## Use of `.local` Hostnames
 
-Where 'href' or 'host' attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst '.local' hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
+Where `href` or `host` attributes are specified in the APIs, it is STRONGLY RECOMMENDED to use either IP addresses or hostnames which are resolvable using unicast DNS. Whilst `.local` hostnames are convenient in a zero-configuration layer 2 network segment, these are not usually resolvable beyond these boundaries. As this specification is intended for use between layer 3 network segments, use of these hostnames might result in Nodes appearing inaccessible.
 
 ## Un-initialised Senders and Receivers
 

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -8,7 +8,7 @@ When this API is used alongside IS-04 in a deployment, the IS-04 APIs SHOULD be 
 
 ## Discovery
 
-The Connection Management API SHOULD be advertised as a `control` endpoint when publishing a compliant NMOS Device.
+The Connection Management API SHOULD be advertised as a control endpoint when publishing a compliant NMOS Device.
 Control interfaces can identify all Devices which implement the Connection Management API by a `type` Uniform Resource Name (URN) having the base `urn:x-nmos:control:sr-ctrl` followed by a `/` character and the API version.
 The associated `href` is the URL of the Connection API base resource.
 
@@ -29,7 +29,7 @@ As shown above the API version is included in the `type`, and in the `href`. Fur
 
 More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate `control` endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
+A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate endpoint for each Device's Connection Management instance MUST be advertised in the Device's `controls`, even if the URI is the same.
 
 API implementations MAY list an `href` with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto `href`s.
 
@@ -43,7 +43,7 @@ In order to prevent unnecessary polling of the Connection Management API, change
 
 ## Identifying Active Connections
 
-In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using null) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
+In order to populate the `subscription` attribute of IS-04 Senders and Receivers, the Connection Management API includes keys for `sender_id` and `receiver_id` in its staged parameters. These SHOULD be used to signal that a Sender or Receiver is being connected to another NMOS compatible Sender or Receiver. It is the client's responsibility to set and unset (using `null`) the `sender_id` or `receiver_id` parameters when modifying the `transport_params` or `transport_file`.
 
 ## Support For Legacy IS-04 Connection Management
 

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -47,7 +47,7 @@ In order to populate the `subscription` attribute of IS-04 Senders and Receivers
 
 ## Support For Legacy IS-04 Connection Management
 
-The Connection Management API supersedes the now deprecated method of updating the `target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
+The Connection Management API supersedes the now deprecated method of updating the `/target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
 
 - Where a client updates the Node API subscription, the result on the Connection Management API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
 - Where a client updates a Connection Management API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.

--- a/docs/3.1. Interoperability - NMOS IS-04.md
+++ b/docs/3.1. Interoperability - NMOS IS-04.md
@@ -8,11 +8,11 @@ When this API is used alongside IS-04 in a deployment, the IS-04 APIs SHOULD be 
 
 ## Discovery
 
-The Connection Management API SHOULD be advertised as a 'control' endpoint when publishing a compliant NMOS Device.
-Control interfaces can identify all Devices which implement the Connection Management API by a 'type' Uniform Resource Name (URN) having the base 'urn:x-nmos:control:sr-ctrl' followed by a '/' character and the API version.
-The associated 'href' is the URL of the Connection API base resource.
+The Connection Management API SHOULD be advertised as a `control` endpoint when publishing a compliant NMOS Device.
+Control interfaces can identify all Devices which implement the Connection Management API by a `type` Uniform Resource Name (URN) having the base `urn:x-nmos:control:sr-ctrl` followed by a `/` character and the API version.
+The associated `href` is the URL of the Connection API base resource.
 
-**Example:** The 'controls' attribute of a single NMOS Device
+**Example:** The `controls` attribute of a single NMOS Device
 
 ```json
 ...
@@ -25,13 +25,13 @@ The associated 'href' is the URL of the Connection API base resource.
 ...
 ```
 
-As shown above the API version is included in the 'type', and in the 'href'. Further control endpoints for the Connection Management API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
+As shown above the API version is included in the `type`, and in the `href`. Further control endpoints for the Connection Management API MAY be advertised for Devices which support multiple versions simultaneously, or have multiple network interfaces.
 
 More details about multi-version support can be found in [Upgrade Path](5.0.%20Upgrade%20Path.md).
 
-A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate 'control' endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
+A given instance of the Connection Management API MAY offer control of multiple Devices in a Node from a single URI. Alternatively there MAY be multiple instances of the API on one Node, each corresponding to one Device. A separate `control` endpoint for each Device's Connection Management instance MUST be advertised, even if the URI is the same.
 
-API implementations MAY list an 'href' with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto 'hrefs'.
+API implementations MAY list an `href` with or without a trailing slash, provided that the trailing slash policy in [APIs](2.0.%20APIs.md#urls-approach-to-trailing-slashes) is adhered to. Implementers of clients need to avoid double or missing slashes when appending paths onto `href`s.
 
 ## Sender & Receiver IDs
 
@@ -39,7 +39,7 @@ The UUIDs used to advertise Senders and Receivers in the Connection Management A
 
 ## Version Increments
 
-In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the 'active' parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
+In order to prevent unnecessary polling of the Connection Management API, changes to active connection parameters are signalled via the IS-04 versioning mechanism. When the `active` parameters of a Sender or Receiver are modified, or when a re-activation of the same parameters is performed, the `version` attribute of the relevant IS-04 Sender or Receiver MUST be incremented.
 
 ## Identifying Active Connections
 
@@ -47,7 +47,7 @@ In order to populate the `subscription` attribute of IS-04 Senders and Receivers
 
 ## Support For Legacy IS-04 Connection Management
 
-The Connection Management API supersedes the now deprecated method of updating the 'target' resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
+The Connection Management API supersedes the now deprecated method of updating the `target` resource on Node API Receivers in order to establish connections. The two methods of operation are likely to co-exist until Version 2.0 of IS-04. As such the following best practice SHOULD be followed when both are in use:
 
 - Where a client updates the Node API subscription, the result on the Connection Management API SHOULD be the same as if the client had first staged the parameters and then called an immediate activation. That is to say that the new parameters will be reflected both in the staged and active endpoints of the Receiver.
 - Where a client updates a Connection Management API Receiver the active `sender_id` parameter SHOULD be populated in the Node API subscription parameter with key `sender_id`.

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -8,7 +8,7 @@ If an explicit activation is performed against a Sender or Receiver, the API MUS
 
 ## Transport Files & Caching
 
-It is STRONGLY RECOMMENDED that the following caching headers are included via the /transportfile endpoint (or whatever this endpoint redirects to).
+It is STRONGLY RECOMMENDED that the following caching headers are included via the `/transportfile` endpoint (or whatever this endpoint redirects to).
 
 ```http
 Cache-Control: no-cache
@@ -18,14 +18,14 @@ This is important to ensure that connection management clients do not cache the 
 
 ## Multi-Client Operation
 
-In environments where multiple clients might be operating against a single Connection Management API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP PATCH operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
+In environments where multiple clients might be operating against a single Connection Management API, it is possible that staging of parameters could result in conflicts. There is intentionally no mechanism to prevent this in the API, however clients SHOULD examine the results of HTTP `PATCH` operations which will return the full complement of current settings, allowing the client to confirm that only the changes it had requested have been made.
 
 ## In-Progress Activations
 
 When an implementation is in the process of activating a new set of transport parameters, concurrent requests to the API from other clients could result in unexpected results. In order to minimise these cases, implementations are RECOMMENDED to adopt the following practice:
 
-- While an activation is in progress, concurrent GET requests to the `/active` resource SHOULD reflect the current configuration of the Sender or Receiver as accurately as possible at the instant of the request.
-- If an API implementation receives a new PATCH request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any GET requests to `/staged` during this time MAY also be blocked until the activation is complete.
+- While an activation is in progress, concurrent `GET` requests to the `/active` resource SHOULD reflect the current configuration of the Sender or Receiver as accurately as possible at the instant of the request.
+- If an API implementation receives a new `PATCH` request to the `/staged` resource while an activation is in progress it SHOULD block the request until the previous activation is complete. Any `GET` requests to `/staged` during this time MAY also be blocked until the activation is complete.
 
 ## Connection Status
 

--- a/docs/4.0. Behaviour.md
+++ b/docs/4.0. Behaviour.md
@@ -8,7 +8,7 @@ If an explicit activation is performed against a Sender or Receiver, the API MUS
 
 ## Transport Files & Caching
 
-It is STRONGLY RECOMMENDED that the following caching headers are included via the `/transportfile` endpoint (or whatever this endpoint redirects to).
+It is strongly RECOMMENDED that the following caching headers are included via the `/transportfile` endpoint (or whatever this endpoint redirects to).
 
 ```http
 Cache-Control: no-cache

--- a/docs/4.1. Behaviour - RTP Transport Type.md
+++ b/docs/4.1. Behaviour - RTP Transport Type.md
@@ -92,10 +92,10 @@ All Senders and Receivers SHOULD comply with RFC 4566 (Session Description Proto
 A Receiver sets the `rtp_enabled` parameter to true for each leg it has configured from the SDP file, unless overridden by the requested `transport_params` as noted below.
 
 In the event that a Receiver is presented with an SDP file and a set of transport parameters that
-contradict each other in the same PATCH request, the transport parameters take priority
+contradict each other in the same `PATCH` request, the transport parameters take priority
 over the SDP file and MUST be the parameters used for activation. This only applies
 in the case where there is contradiction between the SDP file and transport parameters within
-a single PATCH request, in all other cases the most recently received PATCH request takes priority.
+a single `PATCH` request, in all other cases the most recently received `PATCH` request takes priority.
 
 ### Unicast
 

--- a/docs/5.0. Upgrade Path.md
+++ b/docs/5.0. Upgrade Path.md
@@ -18,7 +18,7 @@ Connection Management APIs do not need to provide for forwards compatibility as 
 
 ## Requirements for Connection Management clients
 
-Implementers of Connection Management clients are STRONGLY RECOMMENDED to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
+Implementers of Connection Management clients are strongly RECOMMENDED to support multiple versions of the Connection Management API simultaneously in order to ease the upgrade process in live facilities.
 
 ## Performing Upgrades
 


### PR DESCRIPTION
Currently these use 'quotes' for URLs, parameter names etc, but more recent NMOS specs have used  backticks  for monospace rendering., This is consistent with how examples and other codeblocks appear and look better.

This should be merged (if we choose to do it) before merging docs-language.