### PR TITLE
Fix constraints schemas in order to prevent invalid property values passing unintentionally

### DIFF
--- a/APIs/schemas/constraints-schema-mqtt.json
+++ b/APIs/schemas/constraints-schema-mqtt.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Used to express the dynamic constraints on MQTT transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "required": [
+    "broker_topic",
+    "broker_protocol",
+    "broker_authorization",
+    "connection_status_broker_topic"
+  ],
   "additionalProperties": false,
   "patternProperties": {
     "^ext_[a-zA-Z0-9_]+$":{

--- a/APIs/schemas/constraints-schema-mqtt.json
+++ b/APIs/schemas/constraints-schema-mqtt.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Used to express the dynamic constraints on MQTT transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "additionalProperties": false,
   "patternProperties": {
     "^ext_[a-zA-Z0-9_]+$":{
       "$ref": "constraint-schema.json#/definitions/constraint"

--- a/APIs/schemas/constraints-schema-rtp.json
+++ b/APIs/schemas/constraints-schema-rtp.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Used to express the dynamic constraints on RTP transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "additionalProperties": false,
   "patternProperties": {
     "^ext_[a-zA-Z0-9_]+$":{
       "$ref": "constraint-schema.json#/definitions/constraint"

--- a/APIs/schemas/constraints-schema-rtp.json
+++ b/APIs/schemas/constraints-schema-rtp.json
@@ -2,6 +2,11 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Used to express the dynamic constraints on RTP transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "required": [
+    "source_ip",
+    "destination_port",
+    "rtp_enabled"
+  ],
   "additionalProperties": false,
   "patternProperties": {
     "^ext_[a-zA-Z0-9_]+$":{

--- a/APIs/schemas/constraints-schema-websocket.json
+++ b/APIs/schemas/constraints-schema-websocket.json
@@ -2,6 +2,10 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Used to express the dynamic constraints on WebSocket transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "required": [
+    "connection_uri",
+    "connection_authorization"
+  ],
   "additionalProperties": false,
   "patternProperties": {
     "^ext_[a-zA-Z0-9_]+$":{

--- a/APIs/schemas/constraints-schema-websocket.json
+++ b/APIs/schemas/constraints-schema-websocket.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "description": "Used to express the dynamic constraints on WebSocket transport parameters. These constraints may be set and changed at run time. Every transport parameter must have an entry, even if it is only an empty object.",
+  "additionalProperties": false,
   "patternProperties": {
     "^ext_[a-zA-Z0-9_]+$":{
       "$ref": "constraint-schema.json#/definitions/constraint"


### PR DESCRIPTION
Resolves #146, using similar approach as #99.

(A larger refactoring could be done, with an update to the RAML to replace the _constraints-schema.json_ with separate _receiver-constraints-schema.json_ and _sender-constraints-schema.json_ so that the required sets of properties could be more precise. A further extension would be to handle the different sets of properties so that each set is all-or-nothing.)