### PR TITLE
Remove reference to transport file in staging to Senders

### DIFF
--- a/APIs/ConnectionAPI.raml
+++ b/APIs/ConnectionAPI.raml
@@ -284,8 +284,8 @@ documentation:
                    to other parameters.
                500:
                  description: >
-                   A 500 response may be returned if the transport file could not be parsed, or there is
-                   some failure caused by activation which was not caused by a violation of schema or constraints.
+                   A 500 response may be returned if there is some failure which was not caused by a violation of
+                   schema or constraints.
                  body:
                    type: !include schemas/error.json
                    example: !include ../examples/stage-error.json
@@ -537,7 +537,7 @@ documentation:
              500:
                description: >
                  A 500 response may be returned if the transport file could not be parsed, or there is
-                 some failure caused by activation which was not caused by a violation of schema or constraints.
+                 some failure which was not caused by a violation of schema or constraints.
                body:
                  type: !include schemas/error.json
                  example: !include ../examples/stage-error.json


### PR DESCRIPTION
and activation.

Intended to be editorial, but cf. #40 which this therefore doesn't address