### PR TITLE
Clarify what "requested_time" should be set to when "activation":"mod…

### DIFF
--- a/APIs/schemas/activation-schema.json
+++ b/APIs/schemas/activation-schema.json
@@ -23,7 +23,7 @@
       }]
     },
     "requested_time": {
-      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation. Should be null or not present if 'mode' is null.",
+      "description": "String formatted TAI timestamp (<seconds>:<nanoseconds>) indicating time (absolute or relative) for activation. Should be null or not present if 'mode' is null or activate_immediate.",
       "anyOf": [{
         "type": "string",
         "pattern": "^[0-9]+:[0-9]+$"


### PR DESCRIPTION
…e" is set to "activate_immediate"

It's unclear what "requested_time" should be set to when "activation":"mode" is set to "activate_immediate".  Should it be null or absent or either.  The examples show it set to null but absent doesn't seem unreasonable so I've gone with that option. Please amend as required.