### PR TITLE
Remove duplicate keys from schema defintions

### DIFF
--- a/APIs/schemas/activation-schema.json
+++ b/APIs/schemas/activation-schema.json
@@ -1,6 +1,5 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "type": "object",
   "title": "Activation resource",
   "description": "Parameters concerned with activation of the transport parameters",
   "type": "object",

--- a/APIs/schemas/receiver_transport_params_mqtt.json
+++ b/APIs/schemas/receiver_transport_params_mqtt.json
@@ -3,7 +3,6 @@
   "description": "Describes MQTT Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. MQTT Receivers must support all parameters in this schema.",
   "title": "MQTT Receiver Transport Parameters",
   "type": "object",
-  "title": "Receiver Input",
   "properties": {
     "source_host": {
       "type": [

--- a/APIs/schemas/receiver_transport_params_rtp.json
+++ b/APIs/schemas/receiver_transport_params_rtp.json
@@ -3,7 +3,6 @@
   "description": "Describes RTP Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. Receivers must support at least the `source_ip`, `interface_ip`, `rtp_enabled` and `destination_port` parameters, and must support the `multicast_ip` parameter if they are capable of multicast operation. Receivers supporting FEC and/or RTCP must support parameters prefixed with `fec` and `rtcp` respectively.",
   "title": "RTP Receiver Transport Parameters",
   "type": "object",
-  "title": "Receiver Input",
   "properties": {
     "source_ip": {
       "type": [

--- a/APIs/schemas/receiver_transport_params_websocket.json
+++ b/APIs/schemas/receiver_transport_params_websocket.json
@@ -3,7 +3,6 @@
   "description": "Describes WebSocket Receiver transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. WebSocket Receivers must support all parameters in this schema.",
   "title": "WebSocket Receiver Transport Parameters",
   "type": "object",
-  "title": "Receiver Input",
   "properties": {
     "connection_uri": {
       "type": [

--- a/APIs/schemas/sender_transport_params_mqtt.json
+++ b/APIs/schemas/sender_transport_params_mqtt.json
@@ -3,7 +3,6 @@
   "description": "Describes MQTT Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. MQTT Senders must support all properties in this schema.",
   "title": "MQTT Sender Transport Parameters",
   "type": "object",
-  "title": "Sender Output",
   "properties": {
     "destination_host": {
       "type": [

--- a/APIs/schemas/sender_transport_params_rtp.json
+++ b/APIs/schemas/sender_transport_params_rtp.json
@@ -3,7 +3,6 @@
   "description": "Describes RTP Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. As a minimum all senders must support `source_ip`, `destination_ip`, `source_port`, `rtp_enabled` and `destination_port`. Senders supporting FEC and/or RTCP must support parameters prefixed with `fec` and `rtcp` respectively.",
   "title": "RTP Sender Transport Parameters",
     "type": "object",
-  "title": "Sender Output",
   "properties": {
     "source_ip": {
       "type": "string",

--- a/APIs/schemas/sender_transport_params_websocket.json
+++ b/APIs/schemas/sender_transport_params_websocket.json
@@ -3,7 +3,6 @@
   "description": "Describes WebSocket Sender transport parameters. The constraints in this schema are minimum constraints, but may be further constrained at the constraints endpoint. WebSocket Senders must support all parameters in this schema.",
   "title": "WebSocket Sender Transport Parameters",
   "type": "object",
-  "title": "Sender Output",
   "properties": {
     "connection_uri": {
       "type": [


### PR DESCRIPTION
This seems to be some copy/paste error. 

JSON keys 'should' be unique and a lot of JSON parsing software throws errors on duplicate keys or shows otherwise unpredictable behavior.